### PR TITLE
Prefer root domain match first

### DIFF
--- a/scripts/compare-subdomain-matching.ts
+++ b/scripts/compare-subdomain-matching.ts
@@ -1,7 +1,10 @@
 import type { CargoEntry, CargoEntryType } from "../src/shared/types.ts";
 import { DATA_REMOTE_URL, DATASET_KEYS } from "../src/shared/constants.ts";
 import { decodeEntityStrings } from "../src/shared/html.ts";
-import { matchEntriesByUrl, safeParseUrl } from "../src/lib/matching/matching.ts";
+import {
+  matchEntriesByUrl,
+  safeParseUrl,
+} from "../src/lib/matching/matching.ts";
 import type { UrlEntryMatch } from "../src/lib/matching/matching.ts";
 import {
   resetMatchingConfig,
@@ -216,7 +219,8 @@ const printDiff = (diff: MatchDiff) => {
 
   if (diff.removed.length > 0) {
     console.log("  Removed when enabled:");
-    for (const item of diff.removed) console.log(`    - ${formatSnapshot(item)}`);
+    for (const item of diff.removed)
+      console.log(`    - ${formatSnapshot(item)}`);
   }
 
   if (diff.changed.length > 0) {
@@ -271,9 +275,7 @@ const run = async () => {
   console.log(`Fetching Cargo dataset from ${DATA_REMOTE_URL}`);
   const raw = await fetchDataset();
   const dataset = flattenDataset(raw);
-  const urls = hasExplicitUrl
-    ? [String(maybeUrl)]
-    : collectCargoUrls(dataset);
+  const urls = hasExplicitUrl ? [String(maybeUrl)] : collectCargoUrls(dataset);
 
   console.log(`Dataset entries: ${dataset.length}`);
   console.log(`URLs to compare: ${urls.length}`);
@@ -291,8 +293,18 @@ const run = async () => {
     }
 
     const normalizedUrl = parsed.toString();
-    const disabled = runWithSubdomainSetting(dataset, normalizedUrl, matchLimit, false);
-    const enabled = runWithSubdomainSetting(dataset, normalizedUrl, matchLimit, true);
+    const disabled = runWithSubdomainSetting(
+      dataset,
+      normalizedUrl,
+      matchLimit,
+      false,
+    );
+    const enabled = runWithSubdomainSetting(
+      dataset,
+      normalizedUrl,
+      matchLimit,
+      true,
+    );
     const diff = compareSnapshots(normalizedUrl, disabled, enabled);
 
     const changed =
@@ -336,7 +348,9 @@ const run = async () => {
   const limitedDiffs = outputDiffs.slice(0, maxDiffsToPrint);
 
   if (outputDiffs.length === 0) {
-    console.log("No match differences found between subdomain matching disabled vs enabled.");
+    console.log(
+      "No match differences found between subdomain matching disabled vs enabled.",
+    );
     return;
   }
 

--- a/scripts/compare-tld-matching.ts
+++ b/scripts/compare-tld-matching.ts
@@ -1,7 +1,10 @@
 import type { CargoEntry, CargoEntryType } from "../src/shared/types.ts";
 import { DATA_REMOTE_URL, DATASET_KEYS } from "../src/shared/constants.ts";
 import { decodeEntityStrings } from "../src/shared/html.ts";
-import { matchEntriesByUrl, safeParseUrl } from "../src/lib/matching/matching.ts";
+import {
+  matchEntriesByUrl,
+  safeParseUrl,
+} from "../src/lib/matching/matching.ts";
 import type { UrlEntryMatch } from "../src/lib/matching/matching.ts";
 import {
   resetMatchingConfig,
@@ -216,7 +219,8 @@ const printDiff = (diff: MatchDiff) => {
 
   if (diff.removed.length > 0) {
     console.log("  Removed when enabled:");
-    for (const item of diff.removed) console.log(`    - ${formatSnapshot(item)}`);
+    for (const item of diff.removed)
+      console.log(`    - ${formatSnapshot(item)}`);
   }
 
   if (diff.changed.length > 0) {
@@ -271,9 +275,7 @@ const run = async () => {
   console.log(`Fetching Cargo dataset from ${DATA_REMOTE_URL}`);
   const raw = await fetchDataset();
   const dataset = flattenDataset(raw);
-  const urls = hasExplicitUrl
-    ? [String(maybeUrl)]
-    : collectCargoUrls(dataset);
+  const urls = hasExplicitUrl ? [String(maybeUrl)] : collectCargoUrls(dataset);
 
   console.log(`Dataset entries: ${dataset.length}`);
   console.log(`URLs to compare: ${urls.length}`);
@@ -291,7 +293,12 @@ const run = async () => {
     }
 
     const normalizedUrl = parsed.toString();
-    const disabled = runWithTldSetting(dataset, normalizedUrl, matchLimit, false);
+    const disabled = runWithTldSetting(
+      dataset,
+      normalizedUrl,
+      matchLimit,
+      false,
+    );
     const enabled = runWithTldSetting(dataset, normalizedUrl, matchLimit, true);
     const diff = compareSnapshots(normalizedUrl, disabled, enabled);
 
@@ -336,7 +343,9 @@ const run = async () => {
   const limitedDiffs = outputDiffs.slice(0, maxDiffsToPrint);
 
   if (outputDiffs.length === 0) {
-    console.log("No match differences found between cross-TLD matching disabled vs enabled.");
+    console.log(
+      "No match differences found between cross-TLD matching disabled vs enabled.",
+    );
     return;
   }
 

--- a/scripts/update-version.ts
+++ b/scripts/update-version.ts
@@ -18,9 +18,12 @@ const updateJsonVersion = (filePath: string) => {
 
   if (filePath === "manifest/firefox.json" && amoExtensionId) {
     const browserSpecificSettings =
-      (value.browser_specific_settings as Record<string, unknown> | undefined) ??
+      (value.browser_specific_settings as
+        | Record<string, unknown>
+        | undefined) ?? {};
+    const gecko =
+      (browserSpecificSettings.gecko as Record<string, unknown> | undefined) ??
       {};
-    const gecko = (browserSpecificSettings.gecko as Record<string, unknown> | undefined) ?? {};
 
     gecko.id = amoExtensionId;
     browserSpecificSettings.gecko = gecko;

--- a/scripts/url-match-preview.ts
+++ b/scripts/url-match-preview.ts
@@ -99,7 +99,9 @@ const run = async () => {
 
   const raw = await fetchDataset();
   const dataset = flattenDataset(raw);
-  const urls = runExamples ? getCargoExampleUrls(dataset, maxExamples) : [urlArg];
+  const urls = runExamples
+    ? getCargoExampleUrls(dataset, maxExamples)
+    : [urlArg];
 
   if (runExamples) {
     console.log(

--- a/scripts/verify-cargo-quality.ts
+++ b/scripts/verify-cargo-quality.ts
@@ -273,7 +273,9 @@ const validateEntries = (
       });
     } else if (entry._type !== "Incident") {
       const websiteUrls = splitWebsiteField(websiteValue);
-      const hasInvalidUrl = websiteUrls.some((url) => !isParseableWebsiteUrl(url));
+      const hasInvalidUrl = websiteUrls.some(
+        (url) => !isParseableWebsiteUrl(url),
+      );
       const malformedWikiSyntax =
         hasWebsiteSyntaxMarkers(websiteValue) && websiteUrls.length === 0;
 
@@ -296,8 +298,7 @@ const validateEntries = (
     if (entry._type === "Incident") {
       const statusParts =
         typeof entry.Status === "string"
-          ? entry.Status
-              .split(",")
+          ? entry.Status.split(",")
               .map((value) => value.trim())
               .filter(Boolean)
           : [];
@@ -313,7 +314,8 @@ const validateEntries = (
       }
 
       const hasStartDate =
-        typeof entry.StartDate === "string" && entry.StartDate.trim().length > 0;
+        typeof entry.StartDate === "string" &&
+        entry.StartDate.trim().length > 0;
       if (!hasStartDate) {
         pushFinding(groupsByKind, {
           kind: "incident_missing_start_date",
@@ -331,8 +333,7 @@ const validateEntries = (
 
       const statusValues =
         typeof entry.Status === "string"
-          ? entry.Status
-              .split(",")
+          ? entry.Status.split(",")
               .map((value) => value.trim().toLowerCase())
               .filter(Boolean)
           : [];
@@ -403,7 +404,10 @@ const validateEntries = (
   }
 
   const groups = Array.from(groupsByKind.values());
-  const findingCount = groups.reduce((sum, group) => sum + group.items.length, 0);
+  const findingCount = groups.reduce(
+    (sum, group) => sum + group.items.length,
+    0,
+  );
 
   return {
     entries,
@@ -447,10 +451,13 @@ const getMatrixRows = (result: ValidationResult): MatrixRow[] => {
     return String(left.PageID ?? "").localeCompare(String(right.PageID ?? ""));
   });
 
-  return sortedEntries.map((entry) => ({
-    entry,
-    flags: flaggedByEntryKey.get(entryMatrixKey(entry)) ?? new Set<FindingKind>(),
-  })).filter((row) => row.flags.size > 0);
+  return sortedEntries
+    .map((entry) => ({
+      entry,
+      flags:
+        flaggedByEntryKey.get(entryMatrixKey(entry)) ?? new Set<FindingKind>(),
+    }))
+    .filter((row) => row.flags.size > 0);
 };
 
 const padCell = (value: string, width: number): string => {
@@ -549,7 +556,9 @@ const formatTextReport = (result: ValidationResult, args: Args): string => {
   lines.push(
     "Matrix uses ✅ = passes/no issue, ❌ = issue found, - = not applicable",
   );
-  lines.push(`Rows shown: ${matrixRows.length} (pages with at least one issue)`);
+  lines.push(
+    `Rows shown: ${matrixRows.length} (pages with at least one issue)`,
+  );
   lines.push("");
   lines.push("Quality Check Definitions:");
   lines.push(
@@ -629,7 +638,9 @@ const formatWikiReport = (result: ValidationResult, args: Args): string => {
   lines.push(
     "* Matrix uses {{Tick}} = passes/no issue, {{Cross}} = issue found, - = not applicable",
   );
-  lines.push(`* Rows shown: ${matrixRows.length} (pages with at least one issue)`);
+  lines.push(
+    `* Rows shown: ${matrixRows.length} (pages with at least one issue)`,
+  );
   lines.push("");
   lines.push("== Quality Check Definitions ==");
   lines.push(
@@ -667,7 +678,7 @@ const formatWikiReport = (result: ValidationResult, args: Args): string => {
 
   if (matrixRows.length === 0) {
     lines.push("|-");
-    lines.push("| colspan=\"10\" | No pages with quality issues found.");
+    lines.push('| colspan="10" | No pages with quality issues found.');
   } else {
     for (const { entry, flags } of matrixRows) {
       const hasProblem = (kind: FindingKind) => flags.has(kind);
@@ -796,7 +807,9 @@ const loadDataset = async (inputPath?: string): Promise<CargoEntry[]> => {
 
   const response = await fetch(DATA_REMOTE_URL, { cache: "no-store" });
   if (!response.ok) {
-    throw new Error(`Failed to fetch dataset (${response.status}) from ${DATA_REMOTE_URL}`);
+    throw new Error(
+      `Failed to fetch dataset (${response.status}) from ${DATA_REMOTE_URL}`,
+    );
   }
 
   const parsed = (await response.json()) as RawDataset;

--- a/scripts/verify-matching.ts
+++ b/scripts/verify-matching.ts
@@ -120,7 +120,9 @@ const verifyEntryUrls = (
       parsed.toString(),
       Number.MAX_SAFE_INTEGER,
     );
-    const hasSelfMatch = matches.some((match) => entryKey(match.entry) === selfKey);
+    const hasSelfMatch = matches.some(
+      (match) => entryKey(match.entry) === selfKey,
+    );
 
     if (!hasSelfMatch) {
       failures.push({

--- a/src/lib/matching/urlMatching.ts
+++ b/src/lib/matching/urlMatching.ts
@@ -174,7 +174,9 @@ type DetailedUrlEntryMatch = {
 
 const getSubdomainDepth = (hostname: string): number => {
   const hostSegments = hostname.split(".").filter(Boolean).length;
-  const rootSegments = getDomainRoot(hostname).split(".").filter(Boolean).length;
+  const rootSegments = getDomainRoot(hostname)
+    .split(".")
+    .filter(Boolean).length;
   return Math.max(0, hostSegments - rootSegments);
 };
 

--- a/src/lib/matching/urlMatching.ts
+++ b/src/lib/matching/urlMatching.ts
@@ -153,13 +153,6 @@ export const scoreUrlMatch = (detail: UrlMatchDetail): number => {
   return base;
 };
 
-const sortMatches = (left: UrlEntryMatch, right: UrlEntryMatch): number => {
-  if (right.score !== left.score) return right.score - left.score;
-  const byName = left.entry.PageName.localeCompare(right.entry.PageName);
-  if (byName !== 0) return byName;
-  return left.entry.PageID.localeCompare(right.entry.PageID);
-};
-
 const getMatchReasons = (detail: UrlMatchDetail): string[] => {
   if (detail.matchType === "exact") return ["host_equal", "path_equal"];
   if (detail.matchType === "partial") return ["host_equal", "path_prefix"];
@@ -177,6 +170,39 @@ type DetailedUrlEntryMatch = {
   detail: UrlMatchDetail;
   score: number;
   reasons: string[];
+};
+
+const getSubdomainDepth = (hostname: string): number => {
+  const hostSegments = hostname.split(".").filter(Boolean).length;
+  const rootSegments = getDomainRoot(hostname).split(".").filter(Boolean).length;
+  return Math.max(0, hostSegments - rootSegments);
+};
+
+const compareSubdomainDepth = (
+  left: UrlMatchDetail,
+  right: UrlMatchDetail,
+): number => {
+  if (left.matchType !== "subdomain" || right.matchType !== "subdomain") {
+    return 0;
+  }
+
+  const leftDepth = getSubdomainDepth(left.candidateHost);
+  const rightDepth = getSubdomainDepth(right.candidateHost);
+  return leftDepth - rightDepth;
+};
+
+const sortDetailedMatches = (
+  left: DetailedUrlEntryMatch,
+  right: DetailedUrlEntryMatch,
+): number => {
+  if (right.score !== left.score) return right.score - left.score;
+
+  const byDepth = compareSubdomainDepth(left.detail, right.detail);
+  if (byDepth !== 0) return byDepth;
+
+  const byName = left.entry.PageName.localeCompare(right.entry.PageName);
+  if (byName !== 0) return byName;
+  return left.entry.PageID.localeCompare(right.entry.PageID);
 };
 
 const splitWebsiteUrls = (website: unknown): string[] => {
@@ -296,19 +322,19 @@ export const matchEntriesByUrl = (
   for (const match of filterToMostSpecificPathMatches(matches)) {
     const key = getEntryKey(match.entry);
     const existing = bestMatchByEntry.get(key);
-    if (!existing || match.score > existing.score) {
+    if (!existing || sortDetailedMatches(match, existing) < 0) {
       bestMatchByEntry.set(key, match);
     }
   }
 
-  const pruned = Array.from(bestMatchByEntry.values()).map((match) => ({
+  const pruned = Array.from(bestMatchByEntry.values());
+  pruned.sort(sortDetailedMatches);
+
+  return pruned.slice(0, limit).map((match) => ({
     entry: match.entry,
     matchType: match.detail.matchType,
     matchedPath: match.detail.matchedPath,
     score: match.score,
     reasons: match.reasons,
   }));
-
-  pruned.sort(sortMatches);
-  return pruned.slice(0, limit);
 };

--- a/tests/matching.test.ts
+++ b/tests/matching.test.ts
@@ -1,7 +1,10 @@
 import test, { afterEach } from "node:test";
 import assert from "node:assert/strict";
 
-import { matchByPageContext, matchByUrl } from "../src/lib/matching/matching.ts";
+import {
+  matchByPageContext,
+  matchByUrl,
+} from "../src/lib/matching/matching.ts";
 import {
   resetMatchingConfig,
   setMatchingConfig,
@@ -212,7 +215,8 @@ test("matchByPageContext does not use search results page text on google search 
     meta: {
       description: "Search results for fitbit",
       "og:title": "fitbit - Google Search",
-      "og:description": "Search the world's information, including webpages about fitbit",
+      "og:description":
+        "Search the world's information, including webpages about fitbit",
     },
   });
 

--- a/tests/optionsView.component.test.ts
+++ b/tests/optionsView.component.test.ts
@@ -60,9 +60,7 @@ test("OptionsView shows disabled state and removable ignored-site entries", () =
     }),
   );
 
-  assert.ok(
-    html.includes("Disabled: popups will not auto-show on page load."),
-  );
+  assert.ok(html.includes("Disabled: popups will not auto-show on page load."));
   assert.ok(html.includes("example.com"));
   assert.ok(html.includes("airpods"));
   assert.ok(html.includes("Remove"));

--- a/tests/urlMatching.test.ts
+++ b/tests/urlMatching.test.ts
@@ -286,6 +286,37 @@ test("ranks exact above partial above subdomain for non-github hosts", () => {
   assert.equal(results[2].matchType, "subdomain");
 });
 
+test("prefers root domain entries over deeper subdomains when scores tie", () => {
+  setMatchingConfig({ enableSubdomainMatching: true });
+
+  const dataset: CargoEntry[] = [
+    entry({
+      _type: "Company",
+      PageID: "company-fitbit",
+      PageName: "Fitbit",
+      Website: "https://store.google.com/category/watches_trackers",
+    }),
+    entry({
+      _type: "Company",
+      PageID: "company-google",
+      PageName: "Google",
+      Website: "https://www.google.com/",
+    }),
+    entry({
+      _type: "Product",
+      PageID: "product-google-support",
+      PageName: "Google Support",
+      Website: "https://support.google.com/",
+    }),
+  ];
+
+  const results = matchEntriesByUrl(dataset, "https://messages.google.com/", 10);
+
+  assert.equal(results.length, 3);
+  assert.equal(results[0].entry.PageID, "company-google");
+  assert.equal(results[0].matchType, "subdomain");
+});
+
 test("returns empty array for invalid visited URL", () => {
   const results = matchEntriesByUrl([], "not a valid URL", 10);
   assert.deepEqual(results, []);

--- a/tests/urlMatching.test.ts
+++ b/tests/urlMatching.test.ts
@@ -56,7 +56,9 @@ test("preserves path case", () => {
 });
 
 test("treats www and bare domains as equal hosts", () => {
-  const visited = safeParseUrl("https://www.7-eleven.com/7rewards/7-eleven-wallet");
+  const visited = safeParseUrl(
+    "https://www.7-eleven.com/7rewards/7-eleven-wallet",
+  );
   const candidate = safeParseUrl("https://7-eleven.com/");
   assert.ok(visited);
   assert.ok(candidate);
@@ -114,7 +116,10 @@ test("does not classify subdomain match when subdomain matching is disabled", ()
 });
 
 test("does not classify cross-TLD alias match when enableMatchAcrossTLDs is disabled", () => {
-  setMatchingConfig({ enableMatchAcrossTLDs: false, enableSubdomainMatching: true });
+  setMatchingConfig({
+    enableMatchAcrossTLDs: false,
+    enableSubdomainMatching: true,
+  });
   const visited = safeParseUrl("https://www.dyson.co.uk/");
   const candidate = safeParseUrl("https://www.dyson.com/");
   assert.ok(visited);
@@ -125,7 +130,10 @@ test("does not classify cross-TLD alias match when enableMatchAcrossTLDs is disa
 });
 
 test("classifies cross-TLD alias match when enableMatchAcrossTLDs is enabled", () => {
-  setMatchingConfig({ enableMatchAcrossTLDs: true, enableSubdomainMatching: true });
+  setMatchingConfig({
+    enableMatchAcrossTLDs: true,
+    enableSubdomainMatching: true,
+  });
   const visited = safeParseUrl("https://www.dyson.com.au/");
   const candidate = safeParseUrl("https://www.dyson.co.uk/");
   assert.ok(visited);
@@ -138,7 +146,10 @@ test("classifies cross-TLD alias match when enableMatchAcrossTLDs is enabled", (
 });
 
 test("classifies dyson.co.uk and dyson.com as cross-TLD aliases when enabled", () => {
-  setMatchingConfig({ enableMatchAcrossTLDs: true, enableSubdomainMatching: true });
+  setMatchingConfig({
+    enableMatchAcrossTLDs: true,
+    enableSubdomainMatching: true,
+  });
   const visited = safeParseUrl("https://www.dyson.co.uk/");
   const candidate = safeParseUrl("https://www.dyson.com/");
   assert.ok(visited);
@@ -151,7 +162,10 @@ test("classifies dyson.co.uk and dyson.com as cross-TLD aliases when enabled", (
 });
 
 test("does not cross-match unrelated brand TLD hosts sharing generic label", () => {
-  setMatchingConfig({ enableMatchAcrossTLDs: true, enableSubdomainMatching: true });
+  setMatchingConfig({
+    enableMatchAcrossTLDs: true,
+    enableSubdomainMatching: true,
+  });
   const visited = safeParseUrl("https://global.honda/");
   const candidate = safeParseUrl("https://global.canon/");
   assert.ok(visited);
@@ -162,7 +176,10 @@ test("does not cross-match unrelated brand TLD hosts sharing generic label", () 
 });
 
 test("does not bridge brand/generic TLD pairs without compound suffix evidence", () => {
-  setMatchingConfig({ enableMatchAcrossTLDs: true, enableSubdomainMatching: true });
+  setMatchingConfig({
+    enableMatchAcrossTLDs: true,
+    enableSubdomainMatching: true,
+  });
   const visited = safeParseUrl("https://global.brother/");
   const candidate = safeParseUrl("https://www.brother.com/");
   assert.ok(visited);
@@ -173,7 +190,10 @@ test("does not bridge brand/generic TLD pairs without compound suffix evidence",
 });
 
 test("does not cross-match custom TLD host to brand .com without compound suffix evidence", () => {
-  setMatchingConfig({ enableMatchAcrossTLDs: true, enableSubdomainMatching: true });
+  setMatchingConfig({
+    enableMatchAcrossTLDs: true,
+    enableSubdomainMatching: true,
+  });
   const visited = safeParseUrl("https://global.canon/");
   const candidate = safeParseUrl("https://www.canon.com/");
   assert.ok(visited);
@@ -184,7 +204,10 @@ test("does not cross-match custom TLD host to brand .com without compound suffix
 });
 
 test("does not cross-match generic .live TLD sites to yubo.live", () => {
-  setMatchingConfig({ enableMatchAcrossTLDs: true, enableSubdomainMatching: true });
+  setMatchingConfig({
+    enableMatchAcrossTLDs: true,
+    enableSubdomainMatching: true,
+  });
   const visited = safeParseUrl("https://live.com/");
   const candidate = safeParseUrl("https://yubo.live/en");
   assert.ok(visited);
@@ -195,7 +218,10 @@ test("does not cross-match generic .live TLD sites to yubo.live", () => {
 });
 
 test("does not cross-match yubo.live to live.com in reverse direction", () => {
-  setMatchingConfig({ enableMatchAcrossTLDs: true, enableSubdomainMatching: true });
+  setMatchingConfig({
+    enableMatchAcrossTLDs: true,
+    enableSubdomainMatching: true,
+  });
   const visited = safeParseUrl("https://yubo.live/en");
   const candidate = safeParseUrl("https://live.com/");
   assert.ok(visited);
@@ -310,7 +336,11 @@ test("prefers root domain entries over deeper subdomains when scores tie", () =>
     }),
   ];
 
-  const results = matchEntriesByUrl(dataset, "https://messages.google.com/", 10);
+  const results = matchEntriesByUrl(
+    dataset,
+    "https://messages.google.com/",
+    10,
+  );
 
   assert.equal(results.length, 3);
   assert.equal(results[0].entry.PageID, "company-google");
@@ -363,7 +393,11 @@ test("matches entries with comma-separated Website URLs", () => {
     }),
   ];
 
-  const results = matchEntriesByUrl(dataset, "https://speedqueencommercial.com/", 10);
+  const results = matchEntriesByUrl(
+    dataset,
+    "https://speedqueencommercial.com/",
+    10,
+  );
 
   assert.equal(results.length, 1);
   assert.equal(results[0].entry.PageID, "alliance-laundry");
@@ -380,7 +414,11 @@ test("matches entries with space-separated Website URLs", () => {
     }),
   ];
 
-  const results = matchEntriesByUrl(dataset, "https://speedqueencommercial.com/", 10);
+  const results = matchEntriesByUrl(
+    dataset,
+    "https://speedqueencommercial.com/",
+    10,
+  );
 
   assert.equal(results.length, 1);
   assert.equal(results[0].entry.PageID, "alliance-laundry");


### PR DESCRIPTION
Fixes a bug where `messages.google.com` and `Google.com` would show a match for Fitbit instead of Google.