### PR TITLE
Update product parsing logic & meta tag matching

### DIFF
--- a/docs/MATCHING.md
+++ b/docs/MATCHING.md
@@ -7,10 +7,13 @@ The URL matcher behavior is controlled by the exported `matchingConfig` object i
 - `enableSubdomainMatching` (`boolean`, default: `true`): allows matches when the visited URL and candidate URL share the same root domain but use different subdomains (for example `support.example.com` vs `example.com`). Produces a `subdomain` match.
 - `enableMatchAcrossTLDs` (`boolean`, default: `true`): allows cross-TLD alias matches for the same domain label when the suffix is compound and the registrable domains differ (for example `dyson.co.uk` vs `dyson.com.au`). Produces a `subdomain` match with a `cross_tld_alias` reason.
 - `enableEcommerceFamilyAliasMatching` (`boolean`, default: `true`): allows known ecommerce domains in the same configured family (Amazon, eBay, etc.) to match each other across country domains. Produces a `subdomain` match with an `ecommerce_family_alias` reason.
+- `restrictMetaPageContextToEcommerceHosts` (`boolean`, default: `true`): when enabled, title/meta/OG page-context seeds are only used on known ecommerce hosts. Set to `false` to allow those signals on non-ecommerce hosts when URL seeds exist.
 - `urlSeedLimit` (`number`, default: `3`): default limit intended for URL-seed matching workflows.
 - `metaSeedLimit` (`number`, default: `5`): default limit intended for metadata-seed matching workflows.
 - `pageContextMinEntityNameLength` (`number`, default: `3`): minimum entity-name length intended for page-context matching/scoring workflows.
 - `marketplaceBrandDenylist` (`string[]`, default: `["amazon", "ebay"]`): brand names intended to be excluded from page-context brand extraction/scoring.
+- `amazonPropertyMatching` (`{ enabled, useBrand, useManufacturer, brandWeight, manufacturerWeight }`): controls whether Amazon product-property signals (`Brand` / `Manufacturer`) are used in page-context scoring and with what weights.
+- `ebayJsonLdProductMatching` (`{ enabled, useBrand, useManufacturer, brandWeight, manufacturerWeight }`): controls whether eBay `schema.org` Product JSON-LD signals (`brand` / `manufacturer`) are used in page-context scoring and with what weights.
 - `enableSearchResultsPageSuppressions` (`boolean`, default: `true`): globally enables/disables suppression of matches on configured search-result pages (for example Google/Bing/Yahoo/DuckDuckGo search pages).
 - `specificPathDomainMatches` (`string[]`, default: `["github.com"]`): hostnames for which the matcher keeps only the most specific exact/partial path match per host (for example deeper GitHub repo/org paths win over broader `github.com/` matches).
 - `ecommerceDomainFamilyMap` (`Record<string, string>`): maps known ecommerce domains to a family alias used by `enableEcommerceFamilyAliasMatching` (for example many `amazon.*` domains map to `"amazon"`, many `ebay.*` domains map to `"ebay"`).
@@ -28,6 +31,16 @@ The URL matcher behavior is controlled by the exported `matchingConfig` object i
 - `pageContextTypeBoosts.company` (`number`, default: `3`): score boost for entities typed as companies in page-context scoring.
 - `pageContextTypeBoosts.productLine` (`number`, default: `4`): score boost for entities typed as product lines in page-context scoring.
 - `pageContextTypeBoosts.product` (`number`, default: `4`): score boost for entities typed as products in page-context scoring.
+- `amazonPropertyMatching.enabled` (`boolean`, default: `true`): enables Amazon product-property matching signals.
+- `amazonPropertyMatching.useBrand` (`boolean`, default: `true`): includes the extracted Amazon `Brand` property in page-context scoring.
+- `amazonPropertyMatching.useManufacturer` (`boolean`, default: `true`): includes the extracted Amazon `Manufacturer` property in page-context scoring.
+- `amazonPropertyMatching.brandWeight` (`number`, default: `16`): score weight multiplier for Amazon `Brand` property hits.
+- `amazonPropertyMatching.manufacturerWeight` (`number`, default: `12`): score weight multiplier for Amazon `Manufacturer` property hits.
+- `ebayJsonLdProductMatching.enabled` (`boolean`, default: `true`): enables eBay Product JSON-LD matching signals.
+- `ebayJsonLdProductMatching.useBrand` (`boolean`, default: `true`): includes the extracted eBay Product JSON-LD `brand` value in page-context scoring.
+- `ebayJsonLdProductMatching.useManufacturer` (`boolean`, default: `true`): includes the extracted eBay Product JSON-LD `manufacturer` value in page-context scoring.
+- `ebayJsonLdProductMatching.brandWeight` (`number`, default: `14`): score weight multiplier for eBay Product JSON-LD `brand` hits.
+- `ebayJsonLdProductMatching.manufacturerWeight` (`number`, default: `10`): score weight multiplier for eBay Product JSON-LD `manufacturer` hits.
 - `companyAliasSuffixStripping.enabled` (`boolean`, default: `true`): enables alias generation for company names by stripping common legal suffixes / trailing corporate words (for example `Brother Industries Ltd.` can produce `Brother` for page-context matching).
 - `companyAliasSuffixStripping.legalSuffixTokens` (`string[]`): legal suffix tokens that may be removed from the end of a company name when alias generation is enabled (for example `ltd`, `inc`, `llc`).
 - `companyAliasSuffixStripping.genericTrailingTokens` (`string[]`): generic trailing company words that may be removed after legal suffix stripping (for example `industries`, `group`, `holdings`).
@@ -36,5 +49,5 @@ The URL matcher behavior is controlled by the exported `matchingConfig` object i
 ### Current usage notes
 
 - URL matching currently uses `enableSubdomainMatching`, `enableMatchAcrossTLDs`, `enableEcommerceFamilyAliasMatching`, `specificPathDomainMatches`, and `ecommerceDomainFamilyMap`.
-- `matchByPageContext(...)` currently reads `enableSearchResultsPageSuppressions`, `searchResultsPageSuppressions`, and `companyAliasSuffixStripping` (along with related page-context matching logic).
+- `matchByPageContext(...)` currently reads `enableSearchResultsPageSuppressions`, `searchResultsPageSuppressions`, `restrictMetaPageContextToEcommerceHosts`, `companyAliasSuffixStripping`, `amazonPropertyMatching`, and `ebayJsonLdProductMatching` (along with related page-context matching logic).
 - The page-context and seed-limit params are defined in config now for matching/scoring workflows, but are not currently read by `src/lib/matching/urlMatching.ts`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "he": "^1.2.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "tldts": "^7.0.23",
@@ -16,6 +17,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@types/he": "^1.2.3",
         "@types/node": "^25.3.0",
         "@types/react": "^19.2.2",
         "@types/react-dom": "^19.2.2",
@@ -1411,6 +1413,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/he": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/he/-/he-1.2.3.tgz",
+      "integrity": "sha512-q67/qwlxblDzEDvzHhVkwc1gzVWxaNxeyHUBF4xElrvjL11O+Ytze+1fGpBHlr/H9myiBUaUXNnNPmBHxxfAcA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2797,6 +2806,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
       }
     },
     "node_modules/ignore": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:coverage": "node --import tsx --test --experimental-test-coverage tests/*.test.ts"
   },
   "dependencies": {
+    "he": "^1.2.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "tldts": "^7.0.23",
@@ -30,6 +31,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/he": "^1.2.3",
     "@types/node": "^25.3.0",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -12,6 +12,10 @@ import {
   getInlinePopupInstruction,
   type InlinePopupInstruction,
 } from "@/content/messageRouting";
+import {
+  extractAmazonMarketplaceProperties,
+  extractEbayJsonLdProductProperties,
+} from "@/lib/matching/ecommerce";
 
 console.log(
   `${Constants.LOG_PREFIX} Content script loaded on:`,
@@ -408,6 +412,21 @@ const runContentScript = async () => {
   const metaTitle = getMetaContent('meta[name="title"]');
   const ogTitle = getMetaContent('meta[property="og:title"]');
   const ogDescription = getMetaContent('meta[property="og:description"]');
+  const amazonMarketplaceProperties = extractAmazonMarketplaceProperties(
+    document,
+    location.hostname,
+  );
+  const ebayJsonLdMarketplaceProperties = extractEbayJsonLdProductProperties(
+    document,
+    location.hostname,
+  );
+  const marketplaceProperties =
+    amazonMarketplaceProperties || ebayJsonLdMarketplaceProperties
+      ? {
+          ...(amazonMarketplaceProperties || {}),
+          ...(ebayJsonLdMarketplaceProperties || {}),
+        }
+      : undefined;
 
   const context: PageContext = {
     url: location.href,
@@ -419,6 +438,7 @@ const runContentScript = async () => {
       "og:title": ogTitle,
       "og:description": ogDescription,
     },
+    marketplaceProperties,
   };
 
   browser.runtime.sendMessage(

--- a/src/lib/matching/ecommerce.ts
+++ b/src/lib/matching/ecommerce.ts
@@ -10,11 +10,20 @@ const isDomainOrSubdomain = (hostname: string, domain: string): boolean => {
   return host === target || host.endsWith(`.${target}`);
 };
 
-export const ECOMMERCE_DOMAIN_FAMILY_MAP =
-  matchingConfig.ecommerceDomainFamilyMap;
 export const ECOMMERCE_DOMAINS = Object.keys(
   matchingConfig.ecommerceDomainFamilyMap,
 );
+
+const isHostInConfiguredDomainPrefixFamily = (
+  hostname: string,
+  domainPrefix: string,
+): boolean => {
+  return Object.keys(matchingConfig.ecommerceDomainFamilyMap).some((domain) => {
+    const normalizedDomain = normalizeHost(domain);
+    if (!normalizedDomain.startsWith(`${domainPrefix}.`)) return false;
+    return isDomainOrSubdomain(hostname, normalizedDomain);
+  });
+};
 
 export const getEcommerceFamily = (hostname: string): string | null => {
   const host = normalizeHost(hostname);
@@ -27,4 +36,155 @@ export const getEcommerceFamily = (hostname: string): string | null => {
 
 export const isKnownEcommerceHost = (hostname: string): boolean => {
   return getEcommerceFamily(hostname) !== null;
+};
+
+export const isAmazonEcommerceHost = (hostname: string): boolean => {
+  return isHostInConfiguredDomainPrefixFamily(hostname, "amazon");
+};
+
+export const isEbayEcommerceHost = (hostname: string): boolean => {
+  return isHostInConfiguredDomainPrefixFamily(hostname, "ebay");
+};
+
+const normalizePropertyLabel = (value: string): string => {
+  return value
+    .replace(/\u00a0/g, " ")
+    .replace(/[:\s]+/g, " ")
+    .trim()
+    .toLowerCase();
+};
+
+const normalizePropertyValue = (value: string): string => {
+  return value
+    .replace(/\u00a0/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+};
+
+export const extractAmazonMarketplaceProperties = (
+  doc: Document,
+  hostname: string,
+): Record<string, string> | undefined => {
+  if (!isAmazonEcommerceHost(hostname)) return undefined;
+
+  const properties = new Map<string, string>();
+  const targetLabels = new Set(["brand", "manufacturer"]);
+  const setProperty = (label: string, value: string) => {
+    if (!targetLabels.has(label)) return;
+    if (!value) return;
+    if (properties.has(label)) return;
+    properties.set(label, value);
+  };
+
+  for (const row of Array.from(doc.querySelectorAll("tr"))) {
+    const cells = row.querySelectorAll("th, td");
+    if (cells.length < 2) continue;
+    const label = normalizePropertyLabel(cells[0]?.textContent || "");
+    const value = normalizePropertyValue(cells[1]?.textContent || "");
+    setProperty(label, value);
+    if (properties.has("brand") && properties.has("manufacturer")) break;
+  }
+
+  if (!properties.has("brand") || !properties.has("manufacturer")) {
+    for (const listItem of Array.from(doc.querySelectorAll("li"))) {
+      const text = normalizePropertyValue(listItem.textContent || "");
+      if (!text.includes(":")) continue;
+      const [rawLabel, ...rest] = text.split(":");
+      if (!rawLabel || rest.length === 0) continue;
+      const label = normalizePropertyLabel(rawLabel);
+      const value = normalizePropertyValue(rest.join(":"));
+      setProperty(label, value);
+      if (properties.has("brand") && properties.has("manufacturer")) break;
+    }
+  }
+
+  if (properties.size === 0) return undefined;
+  return Object.fromEntries(properties.entries());
+};
+
+export const extractEbayJsonLdProductProperties = (
+  doc: Document,
+  hostname: string,
+): Record<string, string> | undefined => {
+  if (!isEbayEcommerceHost(hostname)) return undefined;
+
+  const productNodes: Array<Record<string, unknown>> = [];
+  const hasProductType = (value: unknown): boolean => {
+    if (typeof value === "string")
+      return value.trim().toLowerCase() === "product";
+    if (Array.isArray(value)) return value.some((item) => hasProductType(item));
+    return false;
+  };
+  const collectProductNodes = (value: unknown): void => {
+    if (!value) return;
+    if (Array.isArray(value)) {
+      for (const item of value) collectProductNodes(item);
+      return;
+    }
+    if (typeof value !== "object") return;
+
+    const node = value as Record<string, unknown>;
+    if (hasProductType(node["@type"])) {
+      productNodes.push(node);
+    }
+    if (node["@graph"]) {
+      collectProductNodes(node["@graph"]);
+    }
+  };
+  const readLinkedName = (value: unknown): string => {
+    if (typeof value === "string") return normalizePropertyValue(value);
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        const name = readLinkedName(item);
+        if (name) return name;
+      }
+      return "";
+    }
+    if (!value || typeof value !== "object") return "";
+
+    const node = value as Record<string, unknown>;
+    if (typeof node.name === "string") {
+      return normalizePropertyValue(node.name);
+    }
+    return "";
+  };
+
+  const scripts = Array.from(
+    doc.querySelectorAll('script[type="application/ld+json"]'),
+  );
+
+  for (const script of scripts) {
+    const text = (script.textContent || "").trim();
+    if (!text) continue;
+
+    try {
+      const payload = JSON.parse(text) as unknown;
+      collectProductNodes(payload);
+    } catch {
+      continue;
+    }
+  }
+
+  if (productNodes.length === 0) return undefined;
+
+  const properties = new Map<string, string>();
+  for (const node of productNodes) {
+    const brand = readLinkedName(node.brand);
+    const manufacturer = readLinkedName(node.manufacturer);
+    if (brand && !properties.has("schemaProductBrand")) {
+      properties.set("schemaProductBrand", brand);
+    }
+    if (manufacturer && !properties.has("schemaProductManufacturer")) {
+      properties.set("schemaProductManufacturer", manufacturer);
+    }
+    if (
+      properties.has("schemaProductBrand") &&
+      properties.has("schemaProductManufacturer")
+    ) {
+      break;
+    }
+  }
+
+  if (properties.size === 0) return undefined;
+  return Object.fromEntries(properties.entries());
 };

--- a/src/lib/matching/matching.ts
+++ b/src/lib/matching/matching.ts
@@ -121,8 +121,12 @@ export const matchByPageContext = (
   if (isSuppressedSearchResultsPage(context)) return [];
 
   const urlMatches = matchEntriesByUrl(entries, context.url, 3);
-  const metaSeeds = matchEntriesByPageContext(entries, context, 5);
   const isEcommerceHost = isKnownEcommerceHost(context.hostname || "");
+  const shouldUseMetaSeeds =
+    isEcommerceHost || !matchingConfig.restrictMetaPageContextToEcommerceHosts;
+  const metaSeeds = shouldUseMetaSeeds
+    ? matchEntriesByPageContext(entries, context, 5)
+    : [];
 
   if (urlMatches.length === 0) {
     if (!isEcommerceHost || metaSeeds.length === 0) return [];

--- a/src/lib/matching/matchingConfig.ts
+++ b/src/lib/matching/matchingConfig.ts
@@ -10,10 +10,27 @@ export type CompanyAliasSuffixStrippingConfig = {
   genericTrailingTokens: string[];
 };
 
+export type AmazonPropertyMatchingConfig = {
+  enabled: boolean;
+  useBrand: boolean;
+  useManufacturer: boolean;
+  brandWeight: number;
+  manufacturerWeight: number;
+};
+
+export type EbayJsonLdProductMatchingConfig = {
+  enabled: boolean;
+  useBrand: boolean;
+  useManufacturer: boolean;
+  brandWeight: number;
+  manufacturerWeight: number;
+};
+
 export type MatchingConfig = {
   enableSubdomainMatching: boolean;
   enableMatchAcrossTLDs: boolean;
   enableEcommerceFamilyAliasMatching: boolean;
+  restrictMetaPageContextToEcommerceHosts: boolean;
   urlSeedLimit: number;
   metaSeedLimit: number;
   urlMatchPriority: {
@@ -35,6 +52,8 @@ export type MatchingConfig = {
   };
   pageContextMinEntityNameLength: number;
   marketplaceBrandDenylist: string[];
+  amazonPropertyMatching: AmazonPropertyMatchingConfig;
+  ebayJsonLdProductMatching: EbayJsonLdProductMatchingConfig;
   companyAliasSuffixStripping: CompanyAliasSuffixStrippingConfig;
   enableSearchResultsPageSuppressions: boolean;
   searchResultsPageSuppressions: SearchResultsPageSuppressionRule[];
@@ -46,6 +65,7 @@ const DEFAULT_MATCHING_CONFIG: MatchingConfig = {
   enableSubdomainMatching: true,
   enableMatchAcrossTLDs: true,
   enableEcommerceFamilyAliasMatching: true,
+  restrictMetaPageContextToEcommerceHosts: true,
   urlSeedLimit: 3,
   metaSeedLimit: 5,
   urlMatchPriority: {
@@ -67,6 +87,20 @@ const DEFAULT_MATCHING_CONFIG: MatchingConfig = {
   },
   pageContextMinEntityNameLength: 3,
   marketplaceBrandDenylist: ["amazon", "ebay"],
+  amazonPropertyMatching: {
+    enabled: true,
+    useBrand: true,
+    useManufacturer: true,
+    brandWeight: 16,
+    manufacturerWeight: 12,
+  },
+  ebayJsonLdProductMatching: {
+    enabled: true,
+    useBrand: true,
+    useManufacturer: true,
+    brandWeight: 14,
+    manufacturerWeight: 10,
+  },
   companyAliasSuffixStripping: {
     enabled: true,
     legalSuffixTokens: [

--- a/src/lib/matching/pageContextMatching.ts
+++ b/src/lib/matching/pageContextMatching.ts
@@ -1,5 +1,6 @@
 import type { CargoEntry, PageContext } from "@/shared/types";
 import { matchingConfig } from "./matchingConfig.ts";
+import { isAmazonEcommerceHost, isEbayEcommerceHost } from "./ecommerce.ts";
 
 type TextMatch = {
   entry: CargoEntry;
@@ -149,13 +150,49 @@ export const matchEntriesByPageContext = (
   context: PageContext,
   limit = 5,
 ): CargoEntry[] => {
+  const isAmazonHost = isAmazonEcommerceHost(context.hostname || "");
+  const isEbayHost = isEbayEcommerceHost(context.hostname || "");
+  const useAmazonPropertySignals =
+    isAmazonHost && matchingConfig.amazonPropertyMatching.enabled;
+  const amazonBrandPropertyText = normalizeText(
+    useAmazonPropertySignals && matchingConfig.amazonPropertyMatching.useBrand
+      ? context.marketplaceProperties?.brand || ""
+      : "",
+  );
+  const amazonManufacturerPropertyText = normalizeText(
+    useAmazonPropertySignals &&
+      matchingConfig.amazonPropertyMatching.useManufacturer
+      ? context.marketplaceProperties?.manufacturer || ""
+      : "",
+  );
+  const hasAmazonPropertySignals =
+    amazonBrandPropertyText.length > 0 ||
+    amazonManufacturerPropertyText.length > 0;
+  const useEbayJsonLdSignals =
+    isEbayHost && matchingConfig.ebayJsonLdProductMatching.enabled;
+  const ebayBrandPropertyText = normalizeText(
+    useEbayJsonLdSignals && matchingConfig.ebayJsonLdProductMatching.useBrand
+      ? context.marketplaceProperties?.schemaProductBrand || ""
+      : "",
+  );
+  const ebayManufacturerPropertyText = normalizeText(
+    useEbayJsonLdSignals &&
+      matchingConfig.ebayJsonLdProductMatching.useManufacturer
+      ? context.marketplaceProperties?.schemaProductManufacturer || ""
+      : "",
+  );
+  const hasEbayPropertySignals =
+    ebayBrandPropertyText.length > 0 || ebayManufacturerPropertyText.length > 0;
+  const hasScopedMarketplacePropertySignals =
+    (useAmazonPropertySignals && hasAmazonPropertySignals) ||
+    (useEbayJsonLdSignals && hasEbayPropertySignals);
   const title = normalizeText(context.title || "");
   const metaTitle = normalizeText(context.meta?.title || "");
   const description = normalizeText(context.meta?.description || "");
   const ogTitle = normalizeText(context.meta?.["og:title"] || "");
   const ogDescription = normalizeText(context.meta?.["og:description"] || "");
   const canonicalText =
-    `${title} ${metaTitle} ${description} ${ogTitle} ${ogDescription}`.trim();
+    `${title} ${metaTitle} ${description} ${ogTitle} ${ogDescription} ${amazonBrandPropertyText} ${amazonManufacturerPropertyText} ${ebayBrandPropertyText} ${ebayManufacturerPropertyText}`.trim();
   if (!canonicalText) return [];
 
   const matches: TextMatch[] = [];
@@ -173,6 +210,10 @@ export const matchEntriesByPageContext = (
     let descriptionHit = 0;
     let ogTitleHit = 0;
     let ogDescriptionHit = 0;
+    let amazonBrandPropertyHit = 0;
+    let amazonManufacturerPropertyHit = 0;
+    let ebayBrandPropertyHit = 0;
+    let ebayManufacturerPropertyHit = 0;
 
     for (const candidate of nameCandidates) {
       if (candidate.length < 2) continue;
@@ -187,13 +228,49 @@ export const matchEntriesByPageContext = (
         ogDescriptionHit,
         phraseScore(ogDescription, candidate),
       );
+      amazonBrandPropertyHit = Math.max(
+        amazonBrandPropertyHit,
+        phraseScore(amazonBrandPropertyText, candidate),
+      );
+      amazonManufacturerPropertyHit = Math.max(
+        amazonManufacturerPropertyHit,
+        phraseScore(amazonManufacturerPropertyText, candidate),
+      );
+      ebayBrandPropertyHit = Math.max(
+        ebayBrandPropertyHit,
+        phraseScore(ebayBrandPropertyText, candidate),
+      );
+      ebayManufacturerPropertyHit = Math.max(
+        ebayManufacturerPropertyHit,
+        phraseScore(ebayManufacturerPropertyText, candidate),
+      );
     }
     if (
       titleHit === 0 &&
       metaTitleHit === 0 &&
       descriptionHit === 0 &&
       ogTitleHit === 0 &&
-      ogDescriptionHit === 0
+      ogDescriptionHit === 0 &&
+      amazonBrandPropertyHit === 0 &&
+      amazonManufacturerPropertyHit === 0 &&
+      ebayBrandPropertyHit === 0 &&
+      ebayManufacturerPropertyHit === 0
+    ) {
+      continue;
+    }
+
+    const marketplacePropertyHitTotal =
+      amazonBrandPropertyHit +
+      amazonManufacturerPropertyHit +
+      ebayBrandPropertyHit +
+      ebayManufacturerPropertyHit;
+
+    // When marketplace-specific structured signals are present, avoid
+    // promoting company matches that come only from generic title/meta text.
+    if (
+      hasScopedMarketplacePropertySignals &&
+      entry._type === "Company" &&
+      marketplacePropertyHitTotal === 0
     ) {
       continue;
     }
@@ -204,6 +281,14 @@ export const matchEntriesByPageContext = (
       descriptionHit * 6 +
       ogTitleHit * 9 +
       ogDescriptionHit * 6 +
+      amazonBrandPropertyHit *
+        matchingConfig.amazonPropertyMatching.brandWeight +
+      amazonManufacturerPropertyHit *
+        matchingConfig.amazonPropertyMatching.manufacturerWeight +
+      ebayBrandPropertyHit *
+        matchingConfig.ebayJsonLdProductMatching.brandWeight +
+      ebayManufacturerPropertyHit *
+        matchingConfig.ebayJsonLdProductMatching.manufacturerWeight +
       typeBoost(entry) +
       pageName.length;
 

--- a/src/shared/html.ts
+++ b/src/shared/html.ts
@@ -1,31 +1,7 @@
-const NAMED_ENTITIES: Record<string, string> = {
-  amp: "&",
-  lt: "<",
-  gt: ">",
-  quot: '"',
-  apos: "'",
-  nbsp: " ",
-};
+import he from "he";
 
 export const decodeHtmlEntities = (value: string): string => {
-  return value.replace(
-    /&(#\d+|#x[0-9a-fA-F]+|[a-zA-Z]+);/g,
-    (match, entity: string) => {
-      if (entity.startsWith("#x") || entity.startsWith("#X")) {
-        const codePoint = Number.parseInt(entity.slice(2), 16);
-        if (Number.isNaN(codePoint)) return match;
-        return String.fromCodePoint(codePoint);
-      }
-
-      if (entity.startsWith("#")) {
-        const codePoint = Number.parseInt(entity.slice(1), 10);
-        if (Number.isNaN(codePoint)) return match;
-        return String.fromCodePoint(codePoint);
-      }
-
-      return NAMED_ENTITIES[entity] ?? match;
-    },
-  );
+  return he.decode(value);
 };
 
 export const decodeEntityStrings = (value: unknown): unknown => {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -27,4 +27,5 @@ export interface PageContext {
   title?: string;
   meta?: Record<string, string>;
   textContent?: string;
+  marketplaceProperties?: Record<string, string>;
 }

--- a/tests/ecommerce.test.ts
+++ b/tests/ecommerce.test.ts
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 
 import {
   ECOMMERCE_DOMAINS,
+  isAmazonEcommerceHost,
+  isEbayEcommerceHost,
   isKnownEcommerceHost,
 } from "../src/lib/matching/ecommerce.ts";
 
@@ -23,4 +25,14 @@ test("detects known ecommerce hosts across Amazon and eBay", () => {
   assert.equal(isKnownEcommerceHost("m.ebay.com.au"), true);
   assert.equal(isKnownEcommerceHost("checkout.ebay.co.uk"), true);
   assert.equal(isKnownEcommerceHost("shop.example.com"), false);
+});
+
+test("classifies Amazon/eBay hosts using ecommerceDomainFamilyMap domains", () => {
+  assert.equal(isAmazonEcommerceHost("www.amazon.com.au"), true);
+  assert.equal(isAmazonEcommerceHost("smile.amazon.co.uk"), true);
+  assert.equal(isAmazonEcommerceHost("www.ebay.com.au"), false);
+
+  assert.equal(isEbayEcommerceHost("www.ebay.com.au"), true);
+  assert.equal(isEbayEcommerceHost("checkout.ebay.de"), true);
+  assert.equal(isEbayEcommerceHost("www.amazon.com.au"), false);
 });

--- a/tests/matching.test.ts
+++ b/tests/matching.test.ts
@@ -28,103 +28,6 @@ test("matchByUrl returns related expanded entries from URL seed matches", () => 
   assert.ok(!ids.includes("company-other"));
 });
 
-const ecommerceFixture = (): CargoEntry[] => {
-  return [
-    entry({
-      _type: "Company",
-      PageID: "company-amazon",
-      PageName: "Amazon",
-      Website: "https://amazon.com.au/",
-    }),
-    entry({
-      _type: "Company",
-      PageID: "company-apple",
-      PageName: "Apple",
-      Website: "https://apple.com/",
-    }),
-    entry({
-      _type: "ProductLine",
-      PageID: "pl-airpods",
-      PageName: "AirPods",
-      Company: "Apple",
-    }),
-    entry({
-      _type: "Incident",
-      PageID: "incident-apple-repair",
-      PageName: "Apple anti-repair practices",
-      Company: "Apple",
-      ProductLine: "AirPods",
-    }),
-  ];
-};
-
-test("matchByPageContext matches ecommerce page when meta/title contain entity", () => {
-  const dataset = ecommerceFixture();
-  const results = matchByPageContext(dataset, {
-    url: "https://www.amazon.com.au/Apple-MXP63ZA-A-AirPods-4/dp/B0DGJ2X3QV",
-    hostname: "www.amazon.com.au",
-    title: "Apple AirPods 4 : Amazon.com.au: Electronics",
-    meta: {
-      description: "Apple AirPods 4 : Amazon.com.au: Electronics",
-    },
-  });
-
-  const ids = results.map((item) => item.PageID);
-  assert.ok(ids.includes("company-apple"));
-  assert.ok(ids.includes("pl-airpods"));
-  assert.ok(ids.includes("incident-apple-repair"));
-});
-
-test("matchByPageContext falls back to ecommerce URL alias matches when meta/title have no entity signal", () => {
-  const dataset = ecommerceFixture();
-  const results = matchByPageContext(dataset, {
-    url: "https://www.amazon.com.au/random-listing/dp/B000000000",
-    hostname: "www.amazon.com.au",
-    title: "Premium USB Cable : Amazon.com.au: Electronics",
-    meta: {
-      description: "Fast charging usb cable bundle",
-    },
-  });
-
-  const ids = results.map((item) => item.PageID);
-  assert.ok(ids.includes("company-amazon"));
-  assert.equal(ids.includes("company-apple"), false);
-});
-
-test("matchByPageContext does not run meta-only matches without URL/domain seed", () => {
-  const dataset = ecommerceFixture();
-  const results = matchByPageContext(dataset, {
-    url: "https://example.org/products/airpods",
-    hostname: "example.org",
-    title: "Apple AirPods 4 review",
-    meta: {
-      description: "Apple AirPods 4 review",
-      "og:title": "Apple AirPods 4 review",
-      "og:description": "Apple AirPods 4 review",
-    },
-  });
-
-  assert.equal(results.length, 0);
-});
-
-test("matchByPageContext allows meta-only matching on ecommerce hosts without URL seed", () => {
-  const dataset = ecommerceFixture();
-  const results = matchByPageContext(dataset, {
-    url: "https://www.ebay.com/itm/1566543210",
-    hostname: "www.ebay.com",
-    title: "Apple AirPods 4 Wireless Earbuds - White | eBay",
-    meta: {
-      description: "Shop Apple AirPods 4 at eBay",
-      "og:title": "Apple AirPods 4 Wireless Earbuds",
-      "og:description": "Buy Apple AirPods on eBay",
-    },
-  });
-
-  const ids = results.map((item) => item.PageID);
-  assert.ok(ids.includes("pl-airpods"));
-  assert.ok(ids.includes("company-apple"));
-});
-
 test("matchByPageContext prioritizes exact non-company URL match before company meta hits", () => {
   const dataset: CargoEntry[] = [
     entry({
@@ -156,34 +59,114 @@ test("matchByPageContext prioritizes exact non-company URL match before company 
   assert.equal(results[0]?.PageID, "pl-wallet");
 });
 
-test("matchByPageContext promotes wallet meta match when URL seed is company", () => {
+test("matchByPageContext promotes meta match when URL seed is company on ecommerce hosts", () => {
   const dataset: CargoEntry[] = [
     entry({
       _type: "Company",
-      PageID: "company-7eleven",
-      PageName: "7-Eleven",
-      Website: "https://7-eleven.com/",
+      PageID: "company-amazon",
+      PageName: "Amazon",
+      Website: "https://amazon.com.au/",
     }),
     entry({
       _type: "ProductLine",
-      PageID: "pl-wallet",
-      PageName: "Wallet",
-      Company: "7-Eleven",
+      PageID: "pl-airpods",
+      PageName: "AirPods",
+      Company: "Apple",
     }),
   ];
 
   const results = matchByPageContext(dataset, {
-    url: "https://www.7-eleven.com/7rewards",
-    hostname: "www.7-eleven.com",
-    title: "7-Eleven Wallet",
+    url: "https://www.amazon.com.au/s?k=airpods",
+    hostname: "www.amazon.com.au",
+    title: "Apple AirPods listing",
     meta: {
-      description: "Use your 7-Eleven Wallet in 7REWARDS",
-      "og:title": "7-Eleven Wallet",
-      "og:description": "Use your 7-Eleven Wallet",
+      description: "Find Apple AirPods deals",
+      "og:title": "Apple AirPods listing",
+      "og:description": "Buy Apple AirPods on Amazon",
     },
   });
 
-  assert.equal(results[0]?.PageID, "pl-wallet");
+  assert.equal(results[0]?.PageID, "pl-airpods");
+});
+
+test("matchByPageContext ignores meta-title seeds on non-ecommerce hosts", () => {
+  const dataset: CargoEntry[] = [
+    entry({
+      _type: "Company",
+      PageID: "company-github",
+      PageName: "GitHub",
+      Website: "https://github.com/",
+    }),
+    entry({
+      _type: "Product",
+      PageID: "product-telegram",
+      PageName: "Telegram",
+      Website: "https://telegram.org/",
+    }),
+  ];
+
+  const results = matchByPageContext(dataset, {
+    url: "https://github.com/qwibitai/nanoclaw",
+    hostname: "github.com",
+    title:
+      "GitHub - qwibitai/nanoclaw: Connects to WhatsApp, Telegram, Slack, Discord",
+    meta: {
+      title:
+        "A lightweight tool that connects to WhatsApp, telegram, Slack, Discord, and Gmail",
+      description:
+        "A lightweight tool that connects to WhatsApp, Telegram, Slack, Discord, and Gmail",
+      "og:title":
+        "GitHub - qwibitai/nanoclaw: Connects to WhatsApp, Telegram, Slack, Discord",
+      "og:description":
+        "A lightweight tool that connects to WhatsApp, Telegram, Slack, Discord, and Gmail",
+    },
+  });
+
+  const ids = results.map((item) => item.PageID);
+  assert.ok(ids.includes("company-github"));
+  assert.equal(ids.includes("product-telegram"), false);
+});
+
+test("matchByPageContext can allow non-ecommerce meta seeds when restriction is disabled", () => {
+  setMatchingConfig({
+    restrictMetaPageContextToEcommerceHosts: false,
+  });
+
+  const dataset: CargoEntry[] = [
+    entry({
+      _type: "Company",
+      PageID: "company-github",
+      PageName: "GitHub",
+      Website: "https://github.com/",
+    }),
+    entry({
+      _type: "Product",
+      PageID: "product-telegram",
+      PageName: "Telegram",
+      Website: "https://telegram.org/",
+    }),
+  ];
+
+  const results = matchByPageContext(dataset, {
+    url: "https://github.com/qwibitai/nanoclaw",
+    hostname: "github.com",
+    title:
+      "GitHub - qwibitai/nanoclaw: Connects to WhatsApp, Telegram, Slack, Discord",
+    meta: {
+      title:
+        "A lightweight tool that connects to WhatsApp, telegram, Slack, Discord, and Gmail",
+      description:
+        "A lightweight tool that connects to WhatsApp, Telegram, Slack, Discord, and Gmail",
+      "og:title":
+        "GitHub - qwibitai/nanoclaw: Connects to WhatsApp, Telegram, Slack, Discord",
+      "og:description":
+        "A lightweight tool that connects to WhatsApp, Telegram, Slack, Discord, and Gmail",
+    },
+  });
+
+  const ids = results.map((item) => item.PageID);
+  assert.ok(ids.includes("company-github"));
+  assert.ok(ids.includes("product-telegram"));
 });
 
 test("matchByPageContext does not use search results page text on google search pages", () => {
@@ -349,33 +332,4 @@ test("matchByPageContext search-results suppression can be disabled via flag", (
 
   const ids = results.map((item) => item.PageID);
   assert.ok(ids.includes("company-google"));
-});
-
-test("matchByPageContext company alias suffix stripping is configurable", () => {
-  setMatchingConfig({
-    companyAliasSuffixStripping: {
-      enabled: false,
-      legalSuffixTokens: [],
-      genericTrailingTokens: [],
-    },
-  });
-
-  const dataset: CargoEntry[] = [
-    entry({
-      _type: "Company",
-      PageID: "company-brother",
-      PageName: "Brother Industries Ltd.",
-    }),
-  ];
-
-  const results = matchByPageContext(dataset, {
-    url: "https://www.amazon.com/Brother-Laser-Printer/dp/B000000002",
-    hostname: "www.amazon.com",
-    title: "Brother Compact Monochrome Laser Printer : Amazon.com",
-    meta: {
-      description: "Brother printer for small office use",
-    },
-  });
-
-  assert.equal(results.length, 0);
 });

--- a/tests/matchingEcommerce.test.ts
+++ b/tests/matchingEcommerce.test.ts
@@ -1,0 +1,564 @@
+import test, { afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+import { matchByPageContext } from "../src/lib/matching/matching.ts";
+import {
+  matchingConfig,
+  resetMatchingConfig,
+  setMatchingConfig,
+} from "../src/lib/matching/matchingConfig.ts";
+import { entry } from "./helpers.ts";
+import type { CargoEntry } from "../src/shared/types.ts";
+
+afterEach(() => {
+  resetMatchingConfig();
+});
+
+const ecommerceFixture = (): CargoEntry[] => {
+  return [
+    entry({
+      _type: "Company",
+      PageID: "company-amazon",
+      PageName: "Amazon",
+      Website: "https://amazon.com.au/",
+    }),
+    entry({
+      _type: "Company",
+      PageID: "company-apple",
+      PageName: "Apple",
+      Website: "https://apple.com/",
+    }),
+    entry({
+      _type: "ProductLine",
+      PageID: "pl-airpods",
+      PageName: "AirPods",
+      Company: "Apple",
+    }),
+    entry({
+      _type: "Incident",
+      PageID: "incident-apple-repair",
+      PageName: "Apple anti-repair practices",
+      Company: "Apple",
+      ProductLine: "AirPods",
+    }),
+  ];
+};
+
+const AMAZON_TOYOTA_EXAMPLE_URL =
+  "https://www.amazon.com.au/SWRTY-61S-Replacement-Retention-Vehicles-2003-2011/dp/B01BM3QGD8";
+const EBAY_AIRPODS_EXAMPLE_URL = "https://www.ebay.com.au/itm/236467312490";
+
+const AMAZON_AUTOBRIDGE_TABLE_HTML = `<tbody><tr class="a-spacing-small po-brand" role="listitem"> <td class="a-span3" role="presentation">     <span class="a-size-base a-text-bold">Brand</span>   </td> <td class="a-span9" role="presentation">    <span class="a-size-base po-break-word">AUTOBRIDGE</span>   </td> </tr>  <tr class="a-spacing-small po-material" role="listitem"> <td class="a-span3" role="presentation">     <span class="a-size-base a-text-bold">Material</span>   </td> <td class="a-span9" role="presentation">    <span class="a-size-base po-break-word">Copper Polyvinyl Chloride (PVC)</span>   </td> </tr>  <tr class="a-spacing-small po-item_dimensions" role="listitem"> <td class="a-span3" role="presentation">     <span class="a-size-base a-text-bold">Item dimensions L x W x H</span>   </td> <td class="a-span9" role="presentation">    <span class="a-size-base po-break-word">25 x 25 x 25 millimetres</span>   </td> </tr>  <tr class="a-spacing-small po-connector_type" role="listitem"> <td class="a-span3" role="presentation">     <span class="a-size-base a-text-bold">Connector type</span>   </td> <td class="a-span9" role="presentation">    <span class="a-size-base po-break-word">3.5mm Jack</span>   </td> </tr>  <tr class="a-spacing-small po-manufacturer" role="listitem"> <td class="a-span3" role="presentation">     <span class="a-size-base a-text-bold">Manufacturer</span>   </td> <td class="a-span9" role="presentation">    <span class="a-size-base po-break-word">AUTOBRIDGE</span>   </td> </tr>    </tbody>`;
+
+const AMAZON_TOYOTA_BRAND_TABLE_HTML = `<tbody><tr class="a-spacing-small po-brand" role="listitem"> <td class="a-span3" role="presentation">     <span class="a-size-base a-text-bold">Brand</span>   </td> <td class="a-span9" role="presentation">    <span class="a-size-base po-break-word">TOYOTA</span>   </td> </tr>  <tr class="a-spacing-small po-material" role="listitem"> <td class="a-span3" role="presentation">     <span class="a-size-base a-text-bold">Material</span>   </td> <td class="a-span9" role="presentation">    <span class="a-size-base po-break-word">Copper Polyvinyl Chloride (PVC)</span>   </td> </tr>  <tr class="a-spacing-small po-item_dimensions" role="listitem"> <td class="a-span3" role="presentation">     <span class="a-size-base a-text-bold">Item dimensions L x W x H</span>   </td> <td class="a-span9" role="presentation">    <span class="a-size-base po-break-word">25 x 25 x 25 millimetres</span>   </td> </tr>  <tr class="a-spacing-small po-connector_type" role="listitem"> <td class="a-span3" role="presentation">     <span class="a-size-base a-text-bold">Connector type</span>   </td> <td class="a-span9" role="presentation">    <span class="a-size-base po-break-word">3.5mm Jack</span>   </td> </tr>  <tr class="a-spacing-small po-manufacturer" role="listitem"> <td class="a-span3" role="presentation">     <span class="a-size-base a-text-bold">Manufacturer</span>   </td> <td class="a-span9" role="presentation">    <span class="a-size-base po-break-word">TOYOTA</span>   </td> </tr>    </tbody>`;
+
+const AMAZON_AUTOBRIDGE_HEAD_HTML = `<head><meta name="title" content="AUTOBRIDGE SWRTY-61S Install New CAR Stereo in Select 2003-2013 Toyota Vehicles Toy : Amazon.com.au: Electronics"><title>AUTOBRIDGE SWRTY-61S Install New CAR Stereo in Select 2003-2013 Toyota Vehicles Toy : Amazon.com.au: Electronics</title><meta name="description" content="AUTOBRIDGE SWRTY-61S Install New CAR Stereo in Select 2003-2013 Toyota Vehicles Toy : Amazon.com.au: Electronics"></head>`;
+
+const AMAZON_TOYOTA_BRAND_HEAD_HTML = `<head><meta name="title" content="TOYOTA SWRTY-61S Install New CAR Stereo in Select 2003-2013 Toyota Vehicles Toy : Amazon.com.au: Electronics"><title>TOYOTA SWRTY-61S Install New CAR Stereo in Select 2003-2013 Toyota Vehicles Toy : Amazon.com.au: Electronics</title><meta name="description" content="TOYOTA SWRTY-61S Install New CAR Stereo in Select 2003-2013 Toyota Vehicles Toy : Amazon.com.au: Electronics"></head>`;
+const EBAY_AIRPODS_JSONLD_SCRIPT = `<script type=application/ld+json>{"@type":"Product","@context":"https://schema.org","name":"For Apple AirPods 4 wireless earphones with USB-C Charging Case 4th + Free Cable","image":["https://i.ebayimg.com/images/g/nYMAAeSwfOJpMmjV/s-l1600.png","https://i.ebayimg.com/images/g/k4wAAeSwPOlpMmjc/s-l1600.png"],"offers":{"@type":"Offer","url":"https://www.ebay.com.au/itm/236467312490","itemCondition":"https://schema.org/NewCondition","availability":"https://schema.org/InStock","priceCurrency":"AUD","price":"59.45"},"model":"Airpods 4th Generation","brand":{"@type":"Brand","name":"Apple"}}</script>`;
+
+const decodeHtmlEntities = (value: string): string => {
+  return value
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">");
+};
+
+const collapseWhitespace = (value: string): string => {
+  return value.replace(/\s+/g, " ").trim();
+};
+
+const extractMetaContent = (headHtml: string, name: string): string => {
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const directPattern = new RegExp(
+    `<meta[^>]*name=["']${escapedName}["'][^>]*content=["']([^"']+)["'][^>]*>`,
+    "i",
+  );
+  const directMatch = headHtml.match(directPattern);
+  if (directMatch?.[1]) {
+    return collapseWhitespace(decodeHtmlEntities(directMatch[1]));
+  }
+
+  const reversePattern = new RegExp(
+    `<meta[^>]*content=["']([^"']+)["'][^>]*name=["']${escapedName}["'][^>]*>`,
+    "i",
+  );
+  const reverseMatch = headHtml.match(reversePattern);
+  if (reverseMatch?.[1]) {
+    return collapseWhitespace(decodeHtmlEntities(reverseMatch[1]));
+  }
+
+  return "";
+};
+
+const extractTitleTag = (headHtml: string): string => {
+  const match = headHtml.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  if (!match?.[1]) return "";
+  return collapseWhitespace(decodeHtmlEntities(match[1]));
+};
+
+const extractMarketplacePropertiesFromTable = (
+  tableHtml: string,
+): Record<string, string> => {
+  const properties: Record<string, string> = {};
+  const rowMatches = tableHtml.match(/<tr[\s\S]*?<\/tr>/gi) || [];
+  for (const row of rowMatches) {
+    const cellMatches = row.match(/<t[dh][^>]*>[\s\S]*?<\/t[dh]>/gi) || [];
+    if (cellMatches.length < 2) continue;
+
+    const key = collapseWhitespace(
+      decodeHtmlEntities(cellMatches[0].replace(/<[^>]+>/g, "")),
+    ).toLowerCase();
+    const value = collapseWhitespace(
+      decodeHtmlEntities(cellMatches[1].replace(/<[^>]+>/g, "")),
+    );
+    if (!value) continue;
+    if (key === "brand") properties.brand = value;
+    if (key === "manufacturer") properties.manufacturer = value;
+  }
+  return properties;
+};
+
+const extractMarketplacePropertiesFromEbayJsonLdScript = (
+  scriptHtml: string,
+): Record<string, string> => {
+  const properties: Record<string, string> = {};
+  const productNodes: Array<Record<string, unknown>> = [];
+  const hasProductType = (value: unknown): boolean => {
+    if (typeof value === "string")
+      return value.trim().toLowerCase() === "product";
+    if (Array.isArray(value)) return value.some((item) => hasProductType(item));
+    return false;
+  };
+  const collectProductNodes = (value: unknown): void => {
+    if (!value) return;
+    if (Array.isArray(value)) {
+      for (const item of value) collectProductNodes(item);
+      return;
+    }
+    if (typeof value !== "object") return;
+    const node = value as Record<string, unknown>;
+    if (hasProductType(node["@type"])) productNodes.push(node);
+    if (node["@graph"]) collectProductNodes(node["@graph"]);
+  };
+  const readLinkedName = (value: unknown): string => {
+    if (typeof value === "string") return collapseWhitespace(value);
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        const name = readLinkedName(item);
+        if (name) return name;
+      }
+      return "";
+    }
+    if (!value || typeof value !== "object") return "";
+    const node = value as Record<string, unknown>;
+    if (typeof node.name === "string") return collapseWhitespace(node.name);
+    return "";
+  };
+
+  const scriptPattern =
+    /<script[^>]*type\s*=\s*["']?application\/ld\+json["']?[^>]*>([\s\S]*?)<\/script>/gi;
+  let match: RegExpExecArray | null = scriptPattern.exec(scriptHtml);
+  while (match) {
+    const payloadRaw = (match[1] || "").trim();
+    if (payloadRaw) {
+      try {
+        const payload = JSON.parse(payloadRaw) as unknown;
+        collectProductNodes(payload);
+      } catch {
+        // Ignore malformed JSON-LD scripts and continue scanning.
+      }
+    }
+    match = scriptPattern.exec(scriptHtml);
+  }
+
+  for (const node of productNodes) {
+    const brand = readLinkedName(node.brand);
+    const manufacturer = readLinkedName(node.manufacturer);
+    if (brand && !properties.schemaProductBrand) {
+      properties.schemaProductBrand = brand;
+    }
+    if (manufacturer && !properties.schemaProductManufacturer) {
+      properties.schemaProductManufacturer = manufacturer;
+    }
+    if (properties.schemaProductBrand && properties.schemaProductManufacturer) {
+      break;
+    }
+  }
+
+  return properties;
+};
+
+test("matchByPageContext matches ecommerce page when meta/title contain entity", () => {
+  const dataset = ecommerceFixture();
+  const results = matchByPageContext(dataset, {
+    url: "https://www.amazon.com.au/Apple-MXP63ZA-A-AirPods-4/dp/B0DGJ2X3QV",
+    hostname: "www.amazon.com.au",
+    title: "Apple AirPods 4 : Amazon.com.au: Electronics",
+    meta: {
+      description: "Apple AirPods 4 : Amazon.com.au: Electronics",
+    },
+  });
+
+  const ids = results.map((item) => item.PageID);
+  assert.ok(ids.includes("company-apple"));
+  assert.ok(ids.includes("pl-airpods"));
+  assert.ok(ids.includes("incident-apple-repair"));
+});
+
+test("matchByPageContext falls back to ecommerce URL alias matches when meta/title have no entity signal", () => {
+  const dataset = ecommerceFixture();
+  const results = matchByPageContext(dataset, {
+    url: "https://www.amazon.com.au/random-listing/dp/B000000000",
+    hostname: "www.amazon.com.au",
+    title: "Premium USB Cable : Amazon.com.au: Electronics",
+    meta: {
+      description: "Fast charging usb cable bundle",
+    },
+  });
+
+  const ids = results.map((item) => item.PageID);
+  assert.ok(ids.includes("company-amazon"));
+  assert.equal(ids.includes("company-apple"), false);
+});
+
+test("matchByPageContext does not run meta-only matches without URL/domain seed", () => {
+  const dataset = ecommerceFixture();
+  const results = matchByPageContext(dataset, {
+    url: "https://example.org/products/airpods",
+    hostname: "example.org",
+    title: "Apple AirPods 4 review",
+    meta: {
+      description: "Apple AirPods 4 review",
+      "og:title": "Apple AirPods 4 review",
+      "og:description": "Apple AirPods 4 review",
+    },
+  });
+
+  assert.equal(results.length, 0);
+});
+
+test("matchByPageContext allows meta-only matching on ecommerce hosts without URL seed", () => {
+  const dataset = ecommerceFixture();
+  const results = matchByPageContext(dataset, {
+    url: "https://www.ebay.com/itm/1566543210",
+    hostname: "www.ebay.com",
+    title: "Apple AirPods 4 Wireless Earbuds - White | eBay",
+    meta: {
+      description: "Shop Apple AirPods 4 at eBay",
+      "og:title": "Apple AirPods 4 Wireless Earbuds",
+      "og:description": "Buy Apple AirPods on eBay",
+    },
+  });
+
+  const ids = results.map((item) => item.PageID);
+  assert.ok(ids.includes("pl-airpods"));
+  assert.ok(ids.includes("company-apple"));
+});
+
+test("matchByPageContext uses eBay Product JSON-LD brand when available", () => {
+  const dataset: CargoEntry[] = [
+    entry({
+      _type: "Company",
+      PageID: "company-ebay",
+      PageName: "eBay",
+      Website: "https://ebay.com.au/",
+    }),
+    entry({
+      _type: "Company",
+      PageID: "company-apple",
+      PageName: "Apple",
+      Website: "https://apple.com/",
+    }),
+  ];
+  const marketplaceProperties =
+    extractMarketplacePropertiesFromEbayJsonLdScript(
+      EBAY_AIRPODS_JSONLD_SCRIPT,
+    );
+  const results = matchByPageContext(dataset, {
+    url: EBAY_AIRPODS_EXAMPLE_URL,
+    hostname: "www.ebay.com.au",
+    title: "Wireless earphones with USB-C Charging Case 4th",
+    meta: {
+      title: "Wireless earphones with USB-C Charging Case 4th",
+      description: "Compatible wireless earphones with charging case",
+    },
+    marketplaceProperties,
+  });
+  const ids = results.map((item) => item.PageID);
+
+  assert.equal(marketplaceProperties.schemaProductBrand, "Apple");
+  assert.equal(results[0]?.PageID, "company-apple");
+  assert.ok(ids.includes("company-ebay"));
+});
+
+test("matchByPageContext eBay Product JSON-LD matching can be disabled via matchingConfig", () => {
+  const dataset: CargoEntry[] = [
+    entry({
+      _type: "Company",
+      PageID: "company-ebay",
+      PageName: "eBay",
+      Website: "https://ebay.com.au/",
+    }),
+    entry({
+      _type: "Company",
+      PageID: "company-apple",
+      PageName: "Apple",
+      Website: "https://apple.com/",
+    }),
+  ];
+  const marketplaceProperties =
+    extractMarketplacePropertiesFromEbayJsonLdScript(
+      EBAY_AIRPODS_JSONLD_SCRIPT,
+    );
+
+  const enabledResults = matchByPageContext(dataset, {
+    url: EBAY_AIRPODS_EXAMPLE_URL,
+    hostname: "www.ebay.com.au",
+    title: "Wireless earphones with USB-C Charging Case 4th",
+    meta: {
+      title: "Wireless earphones with USB-C Charging Case 4th",
+      description: "Compatible wireless earphones with charging case",
+    },
+    marketplaceProperties,
+  });
+  assert.equal(enabledResults[0]?.PageID, "company-apple");
+
+  setMatchingConfig({
+    ebayJsonLdProductMatching: {
+      ...matchingConfig.ebayJsonLdProductMatching,
+      enabled: false,
+    },
+  });
+
+  const disabledResults = matchByPageContext(dataset, {
+    url: EBAY_AIRPODS_EXAMPLE_URL,
+    hostname: "www.ebay.com.au",
+    title: "Wireless earphones with USB-C Charging Case 4th",
+    meta: {
+      title: "Wireless earphones with USB-C Charging Case 4th",
+      description: "Compatible wireless earphones with charging case",
+    },
+    marketplaceProperties,
+  });
+  const disabledIds = disabledResults.map((item) => item.PageID);
+
+  assert.equal(disabledResults[0]?.PageID, "company-ebay");
+  assert.equal(disabledIds.includes("company-apple"), false);
+});
+
+test("matchByPageContext uses Amazon Brand/Manufacturer properties from the provided table snippet", () => {
+  const dataset: CargoEntry[] = [
+    entry({
+      _type: "Company",
+      PageID: "company-amazon",
+      PageName: "Amazon",
+      Website: "https://amazon.com.au/",
+    }),
+    entry({
+      _type: "Company",
+      PageID: "company-autobridge",
+      PageName: "AUTOBRIDGE",
+      Website: "https://autobridge.example/",
+    }),
+  ];
+
+  const marketplaceProperties = extractMarketplacePropertiesFromTable(
+    AMAZON_AUTOBRIDGE_TABLE_HTML,
+  );
+  const context = {
+    url: AMAZON_TOYOTA_EXAMPLE_URL,
+    hostname: "www.amazon.com.au",
+    title: extractTitleTag(AMAZON_AUTOBRIDGE_HEAD_HTML),
+    meta: {
+      title: extractMetaContent(AMAZON_AUTOBRIDGE_HEAD_HTML, "title"),
+      description: extractMetaContent(
+        AMAZON_AUTOBRIDGE_HEAD_HTML,
+        "description",
+      ),
+    },
+    marketplaceProperties,
+  };
+
+  const results = matchByPageContext(dataset, context);
+  const ids = results.map((item) => item.PageID);
+  assert.equal(marketplaceProperties.brand, "AUTOBRIDGE");
+  assert.equal(marketplaceProperties.manufacturer, "AUTOBRIDGE");
+  assert.equal(results[0]?.PageID, "company-autobridge");
+  assert.ok(ids.includes("company-amazon"));
+});
+
+test("matchByPageContext Amazon Brand/Manufacturer matching can be disabled via matchingConfig", () => {
+  const dataset: CargoEntry[] = [
+    entry({
+      _type: "Company",
+      PageID: "company-amazon",
+      PageName: "Amazon",
+      Website: "https://amazon.com.au/",
+    }),
+    entry({
+      _type: "Company",
+      PageID: "company-autobridge",
+      PageName: "AUTOBRIDGE",
+      Website: "https://autobridge.example/",
+    }),
+  ];
+  const marketplaceProperties = extractMarketplacePropertiesFromTable(
+    AMAZON_AUTOBRIDGE_TABLE_HTML,
+  );
+
+  const enabledResults = matchByPageContext(dataset, {
+    url: AMAZON_TOYOTA_EXAMPLE_URL,
+    hostname: "www.amazon.com.au",
+    title: "Install New CAR Stereo in Select Toyota Vehicles",
+    meta: {
+      title: "Install New CAR Stereo in Select Toyota Vehicles",
+      description: "Single DIN harness replacement for selected models",
+    },
+    marketplaceProperties,
+  });
+  assert.equal(enabledResults[0]?.PageID, "company-autobridge");
+
+  setMatchingConfig({
+    amazonPropertyMatching: {
+      ...matchingConfig.amazonPropertyMatching,
+      enabled: false,
+    },
+  });
+
+  const disabledResults = matchByPageContext(dataset, {
+    url: AMAZON_TOYOTA_EXAMPLE_URL,
+    hostname: "www.amazon.com.au",
+    title: "Install New CAR Stereo in Select Toyota Vehicles",
+    meta: {
+      title: "Install New CAR Stereo in Select Toyota Vehicles",
+      description: "Single DIN harness replacement for selected models",
+    },
+    marketplaceProperties,
+  });
+  const disabledIds = disabledResults.map((item) => item.PageID);
+
+  assert.equal(disabledResults[0]?.PageID, "company-amazon");
+  assert.equal(disabledIds.includes("company-autobridge"), false);
+});
+
+test("matchByPageContext company alias suffix stripping is configurable", () => {
+  setMatchingConfig({
+    companyAliasSuffixStripping: {
+      enabled: false,
+      legalSuffixTokens: [],
+      genericTrailingTokens: [],
+    },
+  });
+
+  const dataset: CargoEntry[] = [
+    entry({
+      _type: "Company",
+      PageID: "company-brother",
+      PageName: "Brother Industries Ltd.",
+    }),
+  ];
+
+  const results = matchByPageContext(dataset, {
+    url: "https://www.amazon.com/Brother-Laser-Printer/dp/B000000002",
+    hostname: "www.amazon.com",
+    title: "Brother Compact Monochrome Laser Printer : Amazon.com",
+    meta: {
+      description: "Brother printer for small office use",
+    },
+  });
+
+  assert.equal(results.length, 0);
+});
+
+test("finds Toyota when Toyota is the Amazon Brand/Manufacturer", () => {
+  const dataset: CargoEntry[] = [
+    entry({
+      _type: "Company",
+      PageID: "company-amazon",
+      PageName: "Amazon",
+      Website: "https://amazon.com.au/",
+    }),
+    entry({
+      _type: "Company",
+      PageID: "company-toyota",
+      PageName: "Toyota",
+      Website: "https://toyota.com/",
+    }),
+    entry({
+      _type: "Company",
+      PageID: "company-autobridge",
+      PageName: "AUTOBRIDGE",
+      Website: "https://autobridge.example/",
+    }),
+  ];
+
+  const marketplaceProperties = extractMarketplacePropertiesFromTable(
+    AMAZON_TOYOTA_BRAND_TABLE_HTML,
+  );
+  const results = matchByPageContext(dataset, {
+    url: AMAZON_TOYOTA_EXAMPLE_URL,
+    hostname: "www.amazon.com.au",
+    title: extractTitleTag(AMAZON_TOYOTA_BRAND_HEAD_HTML),
+    meta: {
+      title: extractMetaContent(AMAZON_TOYOTA_BRAND_HEAD_HTML, "title"),
+      description: extractMetaContent(
+        AMAZON_TOYOTA_BRAND_HEAD_HTML,
+        "description",
+      ),
+    },
+    marketplaceProperties,
+  });
+  const ids = results.map((item) => item.PageID);
+
+  assert.equal(marketplaceProperties.brand, "TOYOTA");
+  assert.equal(marketplaceProperties.manufacturer, "TOYOTA");
+  assert.equal(results[0]?.PageID, "company-toyota");
+  assert.equal(ids.includes("company-autobridge"), false);
+});
+
+test("does not find Toyota when Toyota is only in product name but Brand/Manufacturer differs", () => {
+  const dataset: CargoEntry[] = [
+    entry({
+      _type: "Company",
+      PageID: "company-amazon",
+      PageName: "Amazon",
+      Website: "https://amazon.com.au/",
+    }),
+    entry({
+      _type: "Company",
+      PageID: "company-toyota",
+      PageName: "Toyota",
+      Website: "https://toyota.com/",
+    }),
+    entry({
+      _type: "Company",
+      PageID: "company-autobridge",
+      PageName: "AUTOBRIDGE",
+      Website: "https://autobridge.example/",
+    }),
+  ];
+
+  const marketplaceProperties = extractMarketplacePropertiesFromTable(
+    AMAZON_AUTOBRIDGE_TABLE_HTML,
+  );
+  const results = matchByPageContext(dataset, {
+    url: AMAZON_TOYOTA_EXAMPLE_URL,
+    hostname: "www.amazon.com.au",
+    title: extractTitleTag(AMAZON_AUTOBRIDGE_HEAD_HTML),
+    meta: {
+      title: extractMetaContent(AMAZON_AUTOBRIDGE_HEAD_HTML, "title"),
+      description: extractMetaContent(
+        AMAZON_AUTOBRIDGE_HEAD_HTML,
+        "description",
+      ),
+    },
+    marketplaceProperties,
+  });
+  const ids = results.map((item) => item.PageID);
+
+  assert.equal(results[0]?.PageID, "company-autobridge");
+  assert.equal(ids.includes("company-toyota"), false);
+});


### PR DESCRIPTION
Changes
* Extended page-context scoring to use both Amazon property signals and eBay JSON-LD signals, and to suppress company matches that only come from generic title/meta when structured marketplace signals exist.
* Disabled meta tag matching for non-ecommerce sites

Fixes scenarios where:
* [this page](https://www.amazon.com.au/SWRTY-61S-Replacement-Retention-Vehicles-2003-2011/dp/B01BM3QGD8) would show match for Toyota.
* [this repo](https://github.com/qwibitai/nanoclaw) would match for Telegram because it has Telegram in `og:description`