### PR TITLE
Activate matching on any site with schema-LD product markup

### DIFF
--- a/docs/MATCHING.md
+++ b/docs/MATCHING.md
@@ -7,13 +7,13 @@ The URL matcher behavior is controlled by the exported `matchingConfig` object i
 - `enableSubdomainMatching` (`boolean`, default: `true`): allows matches when the visited URL and candidate URL share the same root domain but use different subdomains (for example `support.example.com` vs `example.com`). Produces a `subdomain` match.
 - `enableMatchAcrossTLDs` (`boolean`, default: `true`): allows cross-TLD alias matches for the same domain label when the suffix is compound and the registrable domains differ (for example `dyson.co.uk` vs `dyson.com.au`). Produces a `subdomain` match with a `cross_tld_alias` reason.
 - `enableEcommerceFamilyAliasMatching` (`boolean`, default: `true`): allows known ecommerce domains in the same configured family (Amazon, eBay, etc.) to match each other across country domains. Produces a `subdomain` match with an `ecommerce_family_alias` reason.
-- `restrictMetaPageContextToEcommerceHosts` (`boolean`, default: `true`): when enabled, title/meta/OG page-context seeds are only used on known ecommerce hosts. Set to `false` to allow those signals on non-ecommerce hosts when URL seeds exist.
+- `restrictMetaPageContextToEcommerceHosts` (`boolean`, default: `true`): when enabled, title/meta/OG page-context seeds are only used on known ecommerce hosts, unless schema Product JSON-LD signals are present. Set to `false` to allow those signals on non-ecommerce hosts when URL seeds exist.
 - `urlSeedLimit` (`number`, default: `3`): default limit intended for URL-seed matching workflows.
 - `metaSeedLimit` (`number`, default: `5`): default limit intended for metadata-seed matching workflows.
 - `pageContextMinEntityNameLength` (`number`, default: `3`): minimum entity-name length intended for page-context matching/scoring workflows.
 - `marketplaceBrandDenylist` (`string[]`, default: `["amazon", "ebay"]`): brand names intended to be excluded from page-context brand extraction/scoring.
 - `amazonPropertyMatching` (`{ enabled, useBrand, useManufacturer, brandWeight, manufacturerWeight }`): controls whether Amazon product-property signals (`Brand` / `Manufacturer`) are used in page-context scoring and with what weights.
-- `ebayJsonLdProductMatching` (`{ enabled, useBrand, useManufacturer, brandWeight, manufacturerWeight }`): controls whether eBay `schema.org` Product JSON-LD signals (`brand` / `manufacturer`) are used in page-context scoring and with what weights.
+- `schemaJsonLdProductMatching` (`{ enabled, useName, useBrand, useManufacturer, nameWeight, brandWeight, manufacturerWeight }`): controls whether `schema.org` Product JSON-LD signals (`name` / `brand` / `manufacturer`) are used in page-context scoring and with what weights.
 - `enableSearchResultsPageSuppressions` (`boolean`, default: `true`): globally enables/disables suppression of matches on configured search-result pages (for example Google/Bing/Yahoo/DuckDuckGo search pages).
 - `specificPathDomainMatches` (`string[]`, default: `["github.com"]`): hostnames for which the matcher keeps only the most specific exact/partial path match per host (for example deeper GitHub repo/org paths win over broader `github.com/` matches).
 - `ecommerceDomainFamilyMap` (`Record<string, string>`): maps known ecommerce domains to a family alias used by `enableEcommerceFamilyAliasMatching` (for example many `amazon.*` domains map to `"amazon"`, many `ebay.*` domains map to `"ebay"`).
@@ -36,11 +36,13 @@ The URL matcher behavior is controlled by the exported `matchingConfig` object i
 - `amazonPropertyMatching.useManufacturer` (`boolean`, default: `true`): includes the extracted Amazon `Manufacturer` property in page-context scoring.
 - `amazonPropertyMatching.brandWeight` (`number`, default: `16`): score weight multiplier for Amazon `Brand` property hits.
 - `amazonPropertyMatching.manufacturerWeight` (`number`, default: `12`): score weight multiplier for Amazon `Manufacturer` property hits.
-- `ebayJsonLdProductMatching.enabled` (`boolean`, default: `true`): enables eBay Product JSON-LD matching signals.
-- `ebayJsonLdProductMatching.useBrand` (`boolean`, default: `true`): includes the extracted eBay Product JSON-LD `brand` value in page-context scoring.
-- `ebayJsonLdProductMatching.useManufacturer` (`boolean`, default: `true`): includes the extracted eBay Product JSON-LD `manufacturer` value in page-context scoring.
-- `ebayJsonLdProductMatching.brandWeight` (`number`, default: `14`): score weight multiplier for eBay Product JSON-LD `brand` hits.
-- `ebayJsonLdProductMatching.manufacturerWeight` (`number`, default: `10`): score weight multiplier for eBay Product JSON-LD `manufacturer` hits.
+- `schemaJsonLdProductMatching.enabled` (`boolean`, default: `true`): enables Product JSON-LD matching signals.
+- `schemaJsonLdProductMatching.useName` (`boolean`, default: `true`): includes extracted Product JSON-LD `name` value in page-context scoring.
+- `schemaJsonLdProductMatching.useBrand` (`boolean`, default: `true`): includes extracted Product JSON-LD `brand` value in page-context scoring.
+- `schemaJsonLdProductMatching.useManufacturer` (`boolean`, default: `true`): includes extracted Product JSON-LD `manufacturer` value in page-context scoring.
+- `schemaJsonLdProductMatching.nameWeight` (`number`, default: `20`): score weight multiplier for Product JSON-LD `name` hits.
+- `schemaJsonLdProductMatching.brandWeight` (`number`, default: `12`): score weight multiplier for Product JSON-LD `brand` hits.
+- `schemaJsonLdProductMatching.manufacturerWeight` (`number`, default: `10`): score weight multiplier for Product JSON-LD `manufacturer` hits.
 - `companyAliasSuffixStripping.enabled` (`boolean`, default: `true`): enables alias generation for company names by stripping common legal suffixes / trailing corporate words (for example `Brother Industries Ltd.` can produce `Brother` for page-context matching).
 - `companyAliasSuffixStripping.legalSuffixTokens` (`string[]`): legal suffix tokens that may be removed from the end of a company name when alias generation is enabled (for example `ltd`, `inc`, `llc`).
 - `companyAliasSuffixStripping.genericTrailingTokens` (`string[]`): generic trailing company words that may be removed after legal suffix stripping (for example `industries`, `group`, `holdings`).
@@ -49,5 +51,5 @@ The URL matcher behavior is controlled by the exported `matchingConfig` object i
 ### Current usage notes
 
 - URL matching currently uses `enableSubdomainMatching`, `enableMatchAcrossTLDs`, `enableEcommerceFamilyAliasMatching`, `specificPathDomainMatches`, and `ecommerceDomainFamilyMap`.
-- `matchByPageContext(...)` currently reads `enableSearchResultsPageSuppressions`, `searchResultsPageSuppressions`, `restrictMetaPageContextToEcommerceHosts`, `companyAliasSuffixStripping`, `amazonPropertyMatching`, and `ebayJsonLdProductMatching` (along with related page-context matching logic).
+- `matchByPageContext(...)` currently reads `enableSearchResultsPageSuppressions`, `searchResultsPageSuppressions`, `restrictMetaPageContextToEcommerceHosts`, `companyAliasSuffixStripping`, `amazonPropertyMatching`, and `schemaJsonLdProductMatching` (along with related page-context matching logic).
 - The page-context and seed-limit params are defined in config now for matching/scoring workflows, but are not currently read by `src/lib/matching/urlMatching.ts`.

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -416,10 +416,8 @@ const runContentScript = async () => {
     document,
     location.hostname,
   );
-  const schemaJsonLdMarketplaceProperties = extractSchemaJsonLdProductProperties(
-    document,
-    location.hostname,
-  );
+  const schemaJsonLdMarketplaceProperties =
+    extractSchemaJsonLdProductProperties(document, location.hostname);
   const marketplaceProperties =
     amazonMarketplaceProperties || schemaJsonLdMarketplaceProperties
       ? {

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/content/messageRouting";
 import {
   extractAmazonMarketplaceProperties,
-  extractEbayJsonLdProductProperties,
+  extractSchemaJsonLdProductProperties,
 } from "@/lib/matching/ecommerce";
 
 console.log(
@@ -416,15 +416,15 @@ const runContentScript = async () => {
     document,
     location.hostname,
   );
-  const ebayJsonLdMarketplaceProperties = extractEbayJsonLdProductProperties(
+  const schemaJsonLdMarketplaceProperties = extractSchemaJsonLdProductProperties(
     document,
     location.hostname,
   );
   const marketplaceProperties =
-    amazonMarketplaceProperties || ebayJsonLdMarketplaceProperties
+    amazonMarketplaceProperties || schemaJsonLdMarketplaceProperties
       ? {
           ...(amazonMarketplaceProperties || {}),
-          ...(ebayJsonLdMarketplaceProperties || {}),
+          ...(schemaJsonLdMarketplaceProperties || {}),
         }
       : undefined;
 

--- a/src/lib/matching/ecommerce.ts
+++ b/src/lib/matching/ecommerce.ts
@@ -102,11 +102,11 @@ export const extractAmazonMarketplaceProperties = (
   return Object.fromEntries(properties.entries());
 };
 
-export const extractEbayJsonLdProductProperties = (
+export const extractSchemaJsonLdProductProperties = (
   doc: Document,
   hostname: string,
 ): Record<string, string> | undefined => {
-  if (!isEbayEcommerceHost(hostname)) return undefined;
+  void hostname;
 
   const productNodes: Array<Record<string, unknown>> = [];
   const hasProductType = (value: unknown): boolean => {
@@ -169,8 +169,12 @@ export const extractEbayJsonLdProductProperties = (
 
   const properties = new Map<string, string>();
   for (const node of productNodes) {
+    const name = readLinkedName(node.name);
     const brand = readLinkedName(node.brand);
     const manufacturer = readLinkedName(node.manufacturer);
+    if (name && !properties.has("schemaProductName")) {
+      properties.set("schemaProductName", name);
+    }
     if (brand && !properties.has("schemaProductBrand")) {
       properties.set("schemaProductBrand", brand);
     }
@@ -178,6 +182,7 @@ export const extractEbayJsonLdProductProperties = (
       properties.set("schemaProductManufacturer", manufacturer);
     }
     if (
+      properties.has("schemaProductName") &&
       properties.has("schemaProductBrand") &&
       properties.has("schemaProductManufacturer")
     ) {

--- a/src/lib/matching/matching.ts
+++ b/src/lib/matching/matching.ts
@@ -155,7 +155,10 @@ export const matchByPageContext = (
     : [];
 
   if (urlMatches.length === 0) {
-    if ((!isEcommerceHost && !hasSchemaJsonLdSignals) || metaSeeds.length === 0) {
+    if (
+      (!isEcommerceHost && !hasSchemaJsonLdSignals) ||
+      metaSeeds.length === 0
+    ) {
       return [];
     }
     return expandRelatedEntries(entries, dedupeSeeds(metaSeeds));

--- a/src/lib/matching/matching.ts
+++ b/src/lib/matching/matching.ts
@@ -46,6 +46,29 @@ const hasWebsite = (entry: CargoEntry): boolean => {
   return typeof entry.Website === "string" && entry.Website.trim().length > 0;
 };
 
+const hasSchemaJsonLdUnlockSignals = (context: PageContext): boolean => {
+  const config = matchingConfig.schemaJsonLdProductMatching;
+  if (!config.enabled) return false;
+
+  const properties = context.marketplaceProperties;
+  if (!properties) return false;
+
+  const hasName =
+    config.useName &&
+    typeof properties.schemaProductName === "string" &&
+    properties.schemaProductName.trim().length > 0;
+  const hasBrand =
+    config.useBrand &&
+    typeof properties.schemaProductBrand === "string" &&
+    properties.schemaProductBrand.trim().length > 0;
+  const hasManufacturer =
+    config.useManufacturer &&
+    typeof properties.schemaProductManufacturer === "string" &&
+    properties.schemaProductManufacturer.trim().length > 0;
+
+  return hasName || hasBrand || hasManufacturer;
+};
+
 const hostnameMatchesSuffix = (hostname: string, suffix: string): boolean => {
   const normalizedHost = hostname.toLowerCase();
   const normalizedSuffix = suffix.toLowerCase();
@@ -122,14 +145,19 @@ export const matchByPageContext = (
 
   const urlMatches = matchEntriesByUrl(entries, context.url, 3);
   const isEcommerceHost = isKnownEcommerceHost(context.hostname || "");
+  const hasSchemaJsonLdSignals = hasSchemaJsonLdUnlockSignals(context);
   const shouldUseMetaSeeds =
-    isEcommerceHost || !matchingConfig.restrictMetaPageContextToEcommerceHosts;
+    isEcommerceHost ||
+    hasSchemaJsonLdSignals ||
+    !matchingConfig.restrictMetaPageContextToEcommerceHosts;
   const metaSeeds = shouldUseMetaSeeds
     ? matchEntriesByPageContext(entries, context, 5)
     : [];
 
   if (urlMatches.length === 0) {
-    if (!isEcommerceHost || metaSeeds.length === 0) return [];
+    if ((!isEcommerceHost && !hasSchemaJsonLdSignals) || metaSeeds.length === 0) {
+      return [];
+    }
     return expandRelatedEntries(entries, dedupeSeeds(metaSeeds));
   }
 

--- a/src/lib/matching/matchingConfig.ts
+++ b/src/lib/matching/matchingConfig.ts
@@ -18,10 +18,12 @@ export type AmazonPropertyMatchingConfig = {
   manufacturerWeight: number;
 };
 
-export type EbayJsonLdProductMatchingConfig = {
+export type SchemaJsonLdProductMatchingConfig = {
   enabled: boolean;
+  useName: boolean;
   useBrand: boolean;
   useManufacturer: boolean;
+  nameWeight: number;
   brandWeight: number;
   manufacturerWeight: number;
 };
@@ -53,7 +55,7 @@ export type MatchingConfig = {
   pageContextMinEntityNameLength: number;
   marketplaceBrandDenylist: string[];
   amazonPropertyMatching: AmazonPropertyMatchingConfig;
-  ebayJsonLdProductMatching: EbayJsonLdProductMatchingConfig;
+  schemaJsonLdProductMatching: SchemaJsonLdProductMatchingConfig;
   companyAliasSuffixStripping: CompanyAliasSuffixStrippingConfig;
   enableSearchResultsPageSuppressions: boolean;
   searchResultsPageSuppressions: SearchResultsPageSuppressionRule[];
@@ -94,11 +96,13 @@ const DEFAULT_MATCHING_CONFIG: MatchingConfig = {
     brandWeight: 16,
     manufacturerWeight: 12,
   },
-  ebayJsonLdProductMatching: {
+  schemaJsonLdProductMatching: {
     enabled: true,
+    useName: true,
     useBrand: true,
     useManufacturer: true,
-    brandWeight: 14,
+    nameWeight: 20,
+    brandWeight: 12,
     manufacturerWeight: 10,
   },
   companyAliasSuffixStripping: {

--- a/src/lib/matching/pageContextMatching.ts
+++ b/src/lib/matching/pageContextMatching.ts
@@ -1,6 +1,6 @@
 import type { CargoEntry, PageContext } from "@/shared/types";
 import { matchingConfig } from "./matchingConfig.ts";
-import { isAmazonEcommerceHost, isEbayEcommerceHost } from "./ecommerce.ts";
+import { isAmazonEcommerceHost } from "./ecommerce.ts";
 
 type TextMatch = {
   entry: CargoEntry;
@@ -151,7 +151,6 @@ export const matchEntriesByPageContext = (
   limit = 5,
 ): CargoEntry[] => {
   const isAmazonHost = isAmazonEcommerceHost(context.hostname || "");
-  const isEbayHost = isEbayEcommerceHost(context.hostname || "");
   const useAmazonPropertySignals =
     isAmazonHost && matchingConfig.amazonPropertyMatching.enabled;
   const amazonBrandPropertyText = normalizeText(
@@ -168,31 +167,37 @@ export const matchEntriesByPageContext = (
   const hasAmazonPropertySignals =
     amazonBrandPropertyText.length > 0 ||
     amazonManufacturerPropertyText.length > 0;
-  const useEbayJsonLdSignals =
-    isEbayHost && matchingConfig.ebayJsonLdProductMatching.enabled;
-  const ebayBrandPropertyText = normalizeText(
-    useEbayJsonLdSignals && matchingConfig.ebayJsonLdProductMatching.useBrand
+  const useSchemaJsonLdSignals = matchingConfig.schemaJsonLdProductMatching.enabled;
+  const schemaNamePropertyText = normalizeText(
+    useSchemaJsonLdSignals && matchingConfig.schemaJsonLdProductMatching.useName
+      ? context.marketplaceProperties?.schemaProductName || ""
+      : "",
+  );
+  const schemaBrandPropertyText = normalizeText(
+    useSchemaJsonLdSignals && matchingConfig.schemaJsonLdProductMatching.useBrand
       ? context.marketplaceProperties?.schemaProductBrand || ""
       : "",
   );
-  const ebayManufacturerPropertyText = normalizeText(
-    useEbayJsonLdSignals &&
-      matchingConfig.ebayJsonLdProductMatching.useManufacturer
+  const schemaManufacturerPropertyText = normalizeText(
+    useSchemaJsonLdSignals &&
+      matchingConfig.schemaJsonLdProductMatching.useManufacturer
       ? context.marketplaceProperties?.schemaProductManufacturer || ""
       : "",
   );
-  const hasEbayPropertySignals =
-    ebayBrandPropertyText.length > 0 || ebayManufacturerPropertyText.length > 0;
+  const hasSchemaPropertySignals =
+    schemaNamePropertyText.length > 0 ||
+    schemaBrandPropertyText.length > 0 ||
+    schemaManufacturerPropertyText.length > 0;
   const hasScopedMarketplacePropertySignals =
     (useAmazonPropertySignals && hasAmazonPropertySignals) ||
-    (useEbayJsonLdSignals && hasEbayPropertySignals);
+    (useSchemaJsonLdSignals && hasSchemaPropertySignals);
   const title = normalizeText(context.title || "");
   const metaTitle = normalizeText(context.meta?.title || "");
   const description = normalizeText(context.meta?.description || "");
   const ogTitle = normalizeText(context.meta?.["og:title"] || "");
   const ogDescription = normalizeText(context.meta?.["og:description"] || "");
   const canonicalText =
-    `${title} ${metaTitle} ${description} ${ogTitle} ${ogDescription} ${amazonBrandPropertyText} ${amazonManufacturerPropertyText} ${ebayBrandPropertyText} ${ebayManufacturerPropertyText}`.trim();
+    `${title} ${metaTitle} ${description} ${ogTitle} ${ogDescription} ${amazonBrandPropertyText} ${amazonManufacturerPropertyText} ${schemaNamePropertyText} ${schemaBrandPropertyText} ${schemaManufacturerPropertyText}`.trim();
   if (!canonicalText) return [];
 
   const matches: TextMatch[] = [];
@@ -212,8 +217,9 @@ export const matchEntriesByPageContext = (
     let ogDescriptionHit = 0;
     let amazonBrandPropertyHit = 0;
     let amazonManufacturerPropertyHit = 0;
-    let ebayBrandPropertyHit = 0;
-    let ebayManufacturerPropertyHit = 0;
+    let schemaNamePropertyHit = 0;
+    let schemaBrandPropertyHit = 0;
+    let schemaManufacturerPropertyHit = 0;
 
     for (const candidate of nameCandidates) {
       if (candidate.length < 2) continue;
@@ -236,13 +242,17 @@ export const matchEntriesByPageContext = (
         amazonManufacturerPropertyHit,
         phraseScore(amazonManufacturerPropertyText, candidate),
       );
-      ebayBrandPropertyHit = Math.max(
-        ebayBrandPropertyHit,
-        phraseScore(ebayBrandPropertyText, candidate),
+      schemaNamePropertyHit = Math.max(
+        schemaNamePropertyHit,
+        phraseScore(schemaNamePropertyText, candidate),
       );
-      ebayManufacturerPropertyHit = Math.max(
-        ebayManufacturerPropertyHit,
-        phraseScore(ebayManufacturerPropertyText, candidate),
+      schemaBrandPropertyHit = Math.max(
+        schemaBrandPropertyHit,
+        phraseScore(schemaBrandPropertyText, candidate),
+      );
+      schemaManufacturerPropertyHit = Math.max(
+        schemaManufacturerPropertyHit,
+        phraseScore(schemaManufacturerPropertyText, candidate),
       );
     }
     if (
@@ -253,8 +263,9 @@ export const matchEntriesByPageContext = (
       ogDescriptionHit === 0 &&
       amazonBrandPropertyHit === 0 &&
       amazonManufacturerPropertyHit === 0 &&
-      ebayBrandPropertyHit === 0 &&
-      ebayManufacturerPropertyHit === 0
+      schemaNamePropertyHit === 0 &&
+      schemaBrandPropertyHit === 0 &&
+      schemaManufacturerPropertyHit === 0
     ) {
       continue;
     }
@@ -262,8 +273,9 @@ export const matchEntriesByPageContext = (
     const marketplacePropertyHitTotal =
       amazonBrandPropertyHit +
       amazonManufacturerPropertyHit +
-      ebayBrandPropertyHit +
-      ebayManufacturerPropertyHit;
+      schemaNamePropertyHit +
+      schemaBrandPropertyHit +
+      schemaManufacturerPropertyHit;
 
     // When marketplace-specific structured signals are present, avoid
     // promoting company matches that come only from generic title/meta text.
@@ -285,10 +297,12 @@ export const matchEntriesByPageContext = (
         matchingConfig.amazonPropertyMatching.brandWeight +
       amazonManufacturerPropertyHit *
         matchingConfig.amazonPropertyMatching.manufacturerWeight +
-      ebayBrandPropertyHit *
-        matchingConfig.ebayJsonLdProductMatching.brandWeight +
-      ebayManufacturerPropertyHit *
-        matchingConfig.ebayJsonLdProductMatching.manufacturerWeight +
+      schemaNamePropertyHit *
+        matchingConfig.schemaJsonLdProductMatching.nameWeight +
+      schemaBrandPropertyHit *
+        matchingConfig.schemaJsonLdProductMatching.brandWeight +
+      schemaManufacturerPropertyHit *
+        matchingConfig.schemaJsonLdProductMatching.manufacturerWeight +
       typeBoost(entry) +
       pageName.length;
 

--- a/src/lib/matching/pageContextMatching.ts
+++ b/src/lib/matching/pageContextMatching.ts
@@ -167,14 +167,16 @@ export const matchEntriesByPageContext = (
   const hasAmazonPropertySignals =
     amazonBrandPropertyText.length > 0 ||
     amazonManufacturerPropertyText.length > 0;
-  const useSchemaJsonLdSignals = matchingConfig.schemaJsonLdProductMatching.enabled;
+  const useSchemaJsonLdSignals =
+    matchingConfig.schemaJsonLdProductMatching.enabled;
   const schemaNamePropertyText = normalizeText(
     useSchemaJsonLdSignals && matchingConfig.schemaJsonLdProductMatching.useName
       ? context.marketplaceProperties?.schemaProductName || ""
       : "",
   );
   const schemaBrandPropertyText = normalizeText(
-    useSchemaJsonLdSignals && matchingConfig.schemaJsonLdProductMatching.useBrand
+    useSchemaJsonLdSignals &&
+      matchingConfig.schemaJsonLdProductMatching.useBrand
       ? context.marketplaceProperties?.schemaProductBrand || ""
       : "",
   );

--- a/tests/matchingEcommerce.test.ts
+++ b/tests/matchingEcommerce.test.ts
@@ -121,7 +121,7 @@ const extractMarketplacePropertiesFromTable = (
   return properties;
 };
 
-const extractMarketplacePropertiesFromEbayJsonLdScript = (
+const extractMarketplacePropertiesFromSchemaJsonLdScript = (
   scriptHtml: string,
 ): Record<string, string> => {
   const properties: Record<string, string> = {};
@@ -175,15 +175,23 @@ const extractMarketplacePropertiesFromEbayJsonLdScript = (
   }
 
   for (const node of productNodes) {
+    const name = readLinkedName(node.name);
     const brand = readLinkedName(node.brand);
     const manufacturer = readLinkedName(node.manufacturer);
+    if (name && !properties.schemaProductName) {
+      properties.schemaProductName = name;
+    }
     if (brand && !properties.schemaProductBrand) {
       properties.schemaProductBrand = brand;
     }
     if (manufacturer && !properties.schemaProductManufacturer) {
       properties.schemaProductManufacturer = manufacturer;
     }
-    if (properties.schemaProductBrand && properties.schemaProductManufacturer) {
+    if (
+      properties.schemaProductName &&
+      properties.schemaProductBrand &&
+      properties.schemaProductManufacturer
+    ) {
       break;
     }
   }
@@ -258,7 +266,7 @@ test("matchByPageContext allows meta-only matching on ecommerce hosts without UR
   assert.ok(ids.includes("company-apple"));
 });
 
-test("matchByPageContext uses eBay Product JSON-LD brand when available", () => {
+test("matchByPageContext uses schema Product JSON-LD brand/name when available", () => {
   const dataset: CargoEntry[] = [
     entry({
       _type: "Company",
@@ -274,7 +282,7 @@ test("matchByPageContext uses eBay Product JSON-LD brand when available", () => 
     }),
   ];
   const marketplaceProperties =
-    extractMarketplacePropertiesFromEbayJsonLdScript(
+    extractMarketplacePropertiesFromSchemaJsonLdScript(
       EBAY_AIRPODS_JSONLD_SCRIPT,
     );
   const results = matchByPageContext(dataset, {
@@ -289,12 +297,16 @@ test("matchByPageContext uses eBay Product JSON-LD brand when available", () => 
   });
   const ids = results.map((item) => item.PageID);
 
+  assert.equal(
+    marketplaceProperties.schemaProductName,
+    "For Apple AirPods 4 wireless earphones with USB-C Charging Case 4th + Free Cable",
+  );
   assert.equal(marketplaceProperties.schemaProductBrand, "Apple");
   assert.equal(results[0]?.PageID, "company-apple");
   assert.ok(ids.includes("company-ebay"));
 });
 
-test("matchByPageContext eBay Product JSON-LD matching can be disabled via matchingConfig", () => {
+test("matchByPageContext schema Product JSON-LD matching can be disabled via matchingConfig", () => {
   const dataset: CargoEntry[] = [
     entry({
       _type: "Company",
@@ -310,7 +322,7 @@ test("matchByPageContext eBay Product JSON-LD matching can be disabled via match
     }),
   ];
   const marketplaceProperties =
-    extractMarketplacePropertiesFromEbayJsonLdScript(
+    extractMarketplacePropertiesFromSchemaJsonLdScript(
       EBAY_AIRPODS_JSONLD_SCRIPT,
     );
 
@@ -327,8 +339,8 @@ test("matchByPageContext eBay Product JSON-LD matching can be disabled via match
   assert.equal(enabledResults[0]?.PageID, "company-apple");
 
   setMatchingConfig({
-    ebayJsonLdProductMatching: {
-      ...matchingConfig.ebayJsonLdProductMatching,
+    schemaJsonLdProductMatching: {
+      ...matchingConfig.schemaJsonLdProductMatching,
       enabled: false,
     },
   });
@@ -347,6 +359,232 @@ test("matchByPageContext eBay Product JSON-LD matching can be disabled via match
 
   assert.equal(disabledResults[0]?.PageID, "company-ebay");
   assert.equal(disabledIds.includes("company-apple"), false);
+});
+
+test("matchByPageContext prioritizes Product.name over brand/manufacturer company hits", () => {
+  const dataset: CargoEntry[] = [
+    entry({
+      _type: "Company",
+      PageID: "company-apple",
+      PageName: "Apple",
+      Website: "https://apple.com/",
+    }),
+    entry({
+      _type: "ProductLine",
+      PageID: "pl-airpods",
+      PageName: "AirPods",
+      Company: "Apple",
+    }),
+  ];
+
+  const results = matchByPageContext(dataset, {
+    url: "https://store.example/products/airpods-case",
+    hostname: "store.example",
+    title: "Wireless Earbuds",
+    meta: {
+      title: "Wireless Earbuds",
+      description: "Charging case bundle",
+    },
+    marketplaceProperties: {
+      schemaProductName: "AirPods",
+      schemaProductBrand: "Apple",
+      schemaProductManufacturer: "Apple",
+    },
+  });
+
+  const ids = results.map((item) => item.PageID);
+  assert.equal(results[0]?.PageID, "pl-airpods");
+  assert.ok(ids.includes("company-apple"));
+});
+
+test("matchByPageContext schema Product.name can unlock matching on non-ecommerce hosts", () => {
+  const dataset: CargoEntry[] = [
+    entry({
+      _type: "ProductLine",
+      PageID: "pl-airpods",
+      PageName: "AirPods",
+      Company: "Apple",
+    }),
+  ];
+
+  const results = matchByPageContext(dataset, {
+    url: "https://shop.example/products/1",
+    hostname: "shop.example",
+    title: "Wireless Earbuds",
+    meta: {
+      description: "Charging case bundle",
+    },
+    marketplaceProperties: {
+      schemaProductName: "AirPods",
+    },
+  });
+
+  assert.equal(results[0]?.PageID, "pl-airpods");
+});
+
+test("matchByPageContext schema Product.brand can unlock matching on non-ecommerce hosts", () => {
+  const dataset: CargoEntry[] = [
+    entry({
+      _type: "Company",
+      PageID: "company-apple",
+      PageName: "Apple",
+      Website: "https://apple.com/",
+    }),
+  ];
+
+  const results = matchByPageContext(dataset, {
+    url: "https://shop.example/products/2",
+    hostname: "shop.example",
+    title: "Wireless Earbuds",
+    meta: {
+      description: "Charging case bundle",
+    },
+    marketplaceProperties: {
+      schemaProductBrand: "Apple",
+    },
+  });
+
+  assert.equal(results[0]?.PageID, "company-apple");
+});
+
+test("matchByPageContext schema Product.manufacturer can unlock matching on non-ecommerce hosts", () => {
+  const dataset: CargoEntry[] = [
+    entry({
+      _type: "Company",
+      PageID: "company-apple",
+      PageName: "Apple",
+      Website: "https://apple.com/",
+    }),
+  ];
+
+  const results = matchByPageContext(dataset, {
+    url: "https://shop.example/products/3",
+    hostname: "shop.example",
+    title: "Wireless Earbuds",
+    meta: {
+      description: "Charging case bundle",
+    },
+    marketplaceProperties: {
+      schemaProductManufacturer: "Apple",
+    },
+  });
+
+  assert.equal(results[0]?.PageID, "company-apple");
+});
+
+test("matchByPageContext can disable schema Product.name scoring/unlock via matchingConfig", () => {
+  const dataset: CargoEntry[] = [
+    entry({
+      _type: "ProductLine",
+      PageID: "pl-airpods",
+      PageName: "AirPods",
+      Company: "Apple",
+    }),
+  ];
+  const context = {
+    url: "https://shop.example/products/4",
+    hostname: "shop.example",
+    title: "Wireless Earbuds",
+    meta: {
+      description: "Charging case bundle",
+    },
+    marketplaceProperties: {
+      schemaProductName: "AirPods",
+    },
+  };
+
+  const enabledResults = matchByPageContext(dataset, context);
+  assert.equal(enabledResults[0]?.PageID, "pl-airpods");
+
+  setMatchingConfig({
+    schemaJsonLdProductMatching: {
+      ...matchingConfig.schemaJsonLdProductMatching,
+      useName: false,
+    },
+  });
+
+  const disabledResults = matchByPageContext(dataset, context);
+  assert.equal(disabledResults.length, 0);
+});
+
+test("matchByPageContext can disable schema Product.brand scoring/unlock via matchingConfig", () => {
+  const dataset: CargoEntry[] = [
+    entry({
+      _type: "Company",
+      PageID: "company-apple",
+      PageName: "Apple",
+      Website: "https://apple.com/",
+    }),
+  ];
+  const context = {
+    url: "https://shop.example/products/5",
+    hostname: "shop.example",
+    title: "Wireless Earbuds",
+    meta: {
+      description: "Charging case bundle",
+    },
+    marketplaceProperties: {
+      schemaProductBrand: "Apple",
+    },
+  };
+
+  const enabledResults = matchByPageContext(dataset, context);
+  assert.equal(enabledResults[0]?.PageID, "company-apple");
+
+  setMatchingConfig({
+    schemaJsonLdProductMatching: {
+      ...matchingConfig.schemaJsonLdProductMatching,
+      useBrand: false,
+    },
+  });
+
+  const disabledResults = matchByPageContext(dataset, context);
+  assert.equal(disabledResults.length, 0);
+});
+
+test("matchByPageContext can disable schema Product.manufacturer scoring/unlock via matchingConfig", () => {
+  const dataset: CargoEntry[] = [
+    entry({
+      _type: "Company",
+      PageID: "company-apple",
+      PageName: "Apple",
+      Website: "https://apple.com/",
+    }),
+  ];
+  const context = {
+    url: "https://shop.example/products/6",
+    hostname: "shop.example",
+    title: "Wireless Earbuds",
+    meta: {
+      description: "Charging case bundle",
+    },
+    marketplaceProperties: {
+      schemaProductManufacturer: "Apple",
+    },
+  };
+
+  const enabledResults = matchByPageContext(dataset, context);
+  assert.equal(enabledResults[0]?.PageID, "company-apple");
+
+  setMatchingConfig({
+    schemaJsonLdProductMatching: {
+      ...matchingConfig.schemaJsonLdProductMatching,
+      useManufacturer: false,
+    },
+  });
+
+  const disabledResults = matchByPageContext(dataset, context);
+  assert.equal(disabledResults.length, 0);
+});
+
+test("extractMarketplacePropertiesFromSchemaJsonLdScript ignores malformed JSON-LD blocks", () => {
+  const properties = extractMarketplacePropertiesFromSchemaJsonLdScript(`
+    <script type="application/ld+json">{"@type":"Product","name":"AirPods"</script>
+    <script type="application/ld+json">{"@type":"Product","brand":{"name":"Apple"}}</script>
+  `);
+
+  assert.equal(properties.schemaProductBrand, "Apple");
+  assert.equal(properties.schemaProductManufacturer, undefined);
 });
 
 test("matchByPageContext uses Amazon Brand/Manufacturer properties from the provided table snippet", () => {


### PR DESCRIPTION
* Automatically enable eCommerce matching for websites containing [Schema-LD annotated product](https://schema.org/Product) pages
* Adjust scoring by name then brand/manufacturer in the schema-LD scenario 