### PR TITLE
Update README with MIT License and CC BY-SA 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,6 @@ The compiled extension will be output in the `dist` folder. Alternatively run ``
 npm run format
 ```
 ## Disclaimer
+The source code for the CRW Extension is licensed under the MIT License.
+
 All references found by this software are not part of CRW Extension and are provided to the end-user under **CC BY-SA 4.0** licensing by the originating site [consumerrights.wiki](https://consumerrights.wiki).


### PR DESCRIPTION
I know there is the badge at the top of the readme, but I scrolled past it a dozen times and only noticed while editing the readme.

This hopefully just clarifies that the project is under MIT.