### PR TITLE
Lower firefox min version to 140

### DIFF
--- a/manifest/firefox.json
+++ b/manifest/firefox.json
@@ -48,7 +48,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "@crw-extension-firefox",
-      "strict_min_version": "147.0",
+      "strict_min_version": "140.0",
       "data_collection_permissions": {
         "required": ["none"],
         "optional": []


### PR DESCRIPTION
Tested against Debian Firefox 140.7.1esr (64-bit).

Resolves: #68