### PR TITLE
feat: redesign popup to prioritize negative incidents

### DIFF
--- a/src/shared/ui/MatchPopupBody.tsx
+++ b/src/shared/ui/MatchPopupBody.tsx
@@ -1,7 +1,12 @@
 import React from "react";
 
 import { CargoEntry } from "@/shared/types";
-import { RelatedGroup, TopMatchBlock } from "@/shared/ui/MatchPopupPrimitives";
+import {
+  IncidentSummary,
+  RelatedGroup,
+  TopMatchBlock,
+  getIncidentPrimaryStatus,
+} from "@/shared/ui/MatchPopupPrimitives";
 import {
   POPUP_CSS,
   POPUP_LAYOUT,
@@ -14,6 +19,7 @@ type MatchPopupBodyProps = {
   externalIconUrl: string;
   visibleIncidents: CargoEntry[];
   expandedIncidents: CargoEntry[];
+  allIncidents: CargoEntry[];
   relatedProducts: CargoEntry[];
   relatedProductLines: CargoEntry[];
   showsRelatedPagesToggle: boolean;
@@ -29,6 +35,7 @@ export const MatchPopupBody = (props: MatchPopupBodyProps) => {
     externalIconUrl,
     visibleIncidents,
     expandedIncidents,
+    allIncidents,
     relatedProducts,
     relatedProductLines,
     showsRelatedPagesToggle,
@@ -36,6 +43,12 @@ export const MatchPopupBody = (props: MatchPopupBodyProps) => {
     showRelatedPages,
     onToggleRelatedPages,
   } = props;
+
+  // Calculate incident statistics
+  const totalIncidentCount = allIncidents.length;
+  const activeIncidentCount = allIncidents.filter(
+    (incident) => getIncidentPrimaryStatus(incident).toLowerCase() === "active",
+  ).length;
 
   const hasExpandableRelatedGroups =
     expandedIncidents.length > 0 ||
@@ -55,6 +68,13 @@ export const MatchPopupBody = (props: MatchPopupBodyProps) => {
 
   return (
     <div style={bodyPanelStyle}>
+      {/* Incident Summary - Most Prominent Element */}
+      <IncidentSummary
+        totalIncidents={totalIncidentCount}
+        activeIncidents={activeIncidentCount}
+      />
+
+      {/* Company/Product Info - Reduced Prominence */}
       <TopMatchBlock
         entry={topMatch}
         companyFallback={companyMatch}

--- a/src/shared/ui/MatchPopupCard.tsx
+++ b/src/shared/ui/MatchPopupCard.tsx
@@ -271,6 +271,7 @@ export const MatchPopupCard = (props: MatchPopupCardProps) => {
         externalIconUrl={externalIconUrl}
         visibleIncidents={visibleIncidents}
         expandedIncidents={expandedIncidents}
+        allIncidents={derived.groupedRelated.Incident}
         relatedProducts={derived.groupedRelated.Product}
         relatedProductLines={derived.groupedRelated.ProductLine}
         showsRelatedPagesToggle={showsRelatedPagesToggle}

--- a/src/shared/ui/MatchPopupPrimitives.tsx
+++ b/src/shared/ui/MatchPopupPrimitives.tsx
@@ -270,6 +270,125 @@ const IncidentEntry = (props: {
   );
 };
 
+type IncidentSummaryProps = {
+  totalIncidents: number;
+  activeIncidents: number;
+};
+
+export const IncidentSummary = (props: IncidentSummaryProps) => {
+  const { totalIncidents, activeIncidents } = props;
+
+  // Determine severity level
+  const getSeverityLevel = (): "high" | "medium" | "low" => {
+    if (activeIncidents > 0) return "high";
+    if (totalIncidents > 0) return "medium";
+    return "low";
+  };
+
+  const severity = getSeverityLevel();
+  const severityColor = {
+    high: POPUP_CSS.severityHigh,
+    medium: POPUP_CSS.severityMedium,
+    low: POPUP_CSS.severityLow,
+  }[severity];
+
+  const severityLabel = {
+    high: "High Risk",
+    medium: "Medium Risk",
+    low: "No Issues",
+  }[severity];
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "8px",
+        background: POPUP_CSS.subtleBg,
+        borderRadius: "10px",
+        padding: "12px",
+        borderLeft: `4px solid ${severityColor}`,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: "8px",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "8px",
+          }}
+        >
+          <div
+            style={{
+              width: "10px",
+              height: "10px",
+              borderRadius: "50%",
+              background: severityColor,
+              boxShadow: `0 0 8px ${severityColor}`,
+            }}
+          />
+          <span
+            style={{
+              fontSize: "16px",
+              fontWeight: 700,
+              color: severityColor,
+            }}
+          >
+            {severityLabel}
+          </span>
+        </div>
+        <span
+          style={{
+            fontSize: "13px",
+            fontWeight: 600,
+            color: POPUP_CSS.text,
+          }}
+        >
+          {totalIncidents} incident{totalIncidents !== 1 ? "s" : ""}
+        </span>
+      </div>
+
+      {activeIncidents > 0 && (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "6px",
+            padding: "6px 10px",
+            background: `${POPUP_CSS.severityHigh}15`,
+            borderRadius: "6px",
+          }}
+        >
+          <span
+            style={{
+              width: "6px",
+              height: "6px",
+              borderRadius: "50%",
+              background: POPUP_CSS.severityHigh,
+            }}
+          />
+          <span
+            style={{
+              fontSize: "12px",
+              fontWeight: 600,
+              color: POPUP_CSS.text,
+            }}
+          >
+            {activeIncidents} active
+          </span>
+        </div>
+      )}
+    </div>
+  );
+};
+
 export const TopMatchBlock = (props: {
   entry: CargoEntry;
   companyFallback?: CargoEntry;
@@ -286,24 +405,24 @@ export const TopMatchBlock = (props: {
       style={{
         display: "flex",
         flexDirection: "column",
-        gap: "6px",
+        gap: "4px",
         background: POPUP_CSS.subtleBg,
-        borderRadius: "10px",
-        padding: "10px",
+        borderRadius: "8px",
+        padding: "8px",
       }}
     >
       <EntryLink
         entry={entry}
         externalIconUrl={externalIconUrl}
         linkStyle={{
-          fontSize: "29px",
-          fontWeight: 700,
-          lineHeight: 1.2,
+          fontSize: "18px",
+          fontWeight: 600,
+          lineHeight: 1.3,
           color: POPUP_CSS.text,
           textDecoration: "none",
           display: "flex",
           alignItems: "center",
-          gap: "8px",
+          gap: "6px",
         }}
         titleStyle={{
           display: "-webkit-box",
@@ -312,7 +431,7 @@ export const TopMatchBlock = (props: {
           overflow: "hidden",
           minWidth: 0,
         }}
-        iconSize={16}
+        iconSize={14}
       />
 
       {entry._type === "Company" && entry.Industry && (

--- a/src/shared/ui/matchPopupStyles.ts
+++ b/src/shared/ui/matchPopupStyles.ts
@@ -11,6 +11,10 @@ export const POPUP_CSS = {
   subtleBg: "rgba(255,255,255,0.08)",
   buttonSecondaryText: "#FFFFFF",
   buttonSecondaryBorder: "rgba(255,255,255,0.38)",
+  // Severity levels for incident summary
+  severityHigh: "#EF4444", // Red - active incidents
+  severityMedium: "#F59E0B", // Amber/Yellow - only resolved incidents
+  severityLow: "#22C55E", // Green - no incidents
 };
 
 export const POPUP_LAYOUT = {


### PR DESCRIPTION
## Summary
Redesigns the extension popup to make negative incidents the main focus instead of company/product information.

## Changes
- **New IncidentSummary component**: Shows incident count and severity level prominently at the top
- **Severity indicators**: Color-coded badges (Red=High Risk with active incidents, Amber=Medium Risk, Green=No Issues)
- **Active incidents badge**: Displays count of ongoing incidents when applicable
- **Reduced company info prominence**: 
  - Font size reduced from 29px to 18px
  - More compact layout
- **Reordered content**: Incident summary now appears first, above company/product details

## Visual Hierarchy
1. Incident Summary (most prominent)
2. Company/Product Info (reduced size)
3. Related Incidents list
4. Related products/lines (if expanded)

## Testing
- Build completes successfully for both Chrome and Firefox
- Component properly calculates incident statistics
- Severity levels render correctly based on incident status

# Screenshot

<img width="457" height="293" alt="image" src="https://github.com/user-attachments/assets/2594cb28-1311-4228-b582-2b30abf64ed8" />
<img width="452" height="541" alt="image" src="https://github.com/user-attachments/assets/eaec7d9c-03ae-4156-8d28-bfbe900a53b4" />
