### PR TITLE
feat: add minimize toggle button to inline popup

### DIFF
--- a/src/content/InlinePopup.tsx
+++ b/src/content/InlinePopup.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 import { CargoEntry } from "@/shared/types";
 import { MatchPopupCard } from "@/shared/ui/MatchPopupCard";
@@ -36,6 +36,12 @@ export const InlinePopup = (props: InlinePopupProps) => {
     disableWarningsLabel,
   } = props;
 
+  const [isMinimized, setIsMinimized] = useState(false);
+
+  const handleToggleMinimize = () => {
+    setIsMinimized((prev) => !prev);
+  };
+
   return (
     <MatchPopupCard
       matches={matches}
@@ -53,6 +59,8 @@ export const InlinePopup = (props: InlinePopupProps) => {
       disableWarningsLabel={disableWarningsLabel}
       showCloseButton
       hideRelatedButtonWhenEmpty
+      isMinimized={isMinimized}
+      onToggleMinimize={handleToggleMinimize}
       containerStyle={{
         position: "fixed",
         right: "16px",

--- a/src/shared/ui/MatchPopupCard.tsx
+++ b/src/shared/ui/MatchPopupCard.tsx
@@ -28,6 +28,8 @@ type MatchPopupCardProps = {
   onOpenSettings?: () => void;
   settingsIconUrl?: string;
   closeIconUrl?: string;
+  isMinimized?: boolean;
+  onToggleMinimize?: () => void;
 };
 
 const VISIBLE_INCIDENT_LIMIT = 4;
@@ -181,6 +183,67 @@ const resolveCompanyMatch = (
   return companyEntries[0];
 };
 
+const MinimizedView = ({
+  logoUrl,
+  incidentCount,
+  hasActiveIncidents,
+  onExpand,
+}: {
+  logoUrl: string;
+  incidentCount: number;
+  hasActiveIncidents: boolean;
+  onExpand: () => void;
+}) => {
+  const badgeStyle: React.CSSProperties = {
+    background: hasActiveIncidents ? "#E74C3C" : "#6B7280",
+    color: "#FFFFFF",
+    borderRadius: "10px",
+    padding: "2px 8px",
+    fontSize: "12px",
+    fontWeight: 600,
+    lineHeight: 1,
+    whiteSpace: "nowrap",
+  };
+
+  return (
+    <div
+      onClick={onExpand}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "8px",
+        cursor: "pointer",
+        padding: "6px 10px",
+        userSelect: "none",
+      }}
+    >
+      <img
+        src={logoUrl}
+        alt="Consumer Rights Wiki"
+        style={{
+          width: "32px",
+          height: "32px",
+          borderRadius: "6px",
+          flexShrink: 0,
+          objectFit: "cover",
+        }}
+      />
+      <div style={badgeStyle}>
+        {incidentCount} {incidentCount === 1 ? "incident" : "incidents"}
+      </div>
+      <span
+        style={{
+          color: POPUP_CSS.muted,
+          fontSize: "12px",
+          marginLeft: "2px",
+        }}
+      >
+        ▼
+      </span>
+    </div>
+  );
+};
+
 export const MatchPopupCard = (props: MatchPopupCardProps) => {
   const {
     matches,
@@ -200,6 +263,8 @@ export const MatchPopupCard = (props: MatchPopupCardProps) => {
     onOpenSettings,
     settingsIconUrl,
     closeIconUrl,
+    isMinimized = false,
+    onToggleMinimize,
   } = props;
 
   const [showRelatedPages, setShowRelatedPages] = useState(false);
@@ -225,15 +290,41 @@ export const MatchPopupCard = (props: MatchPopupCardProps) => {
       Math.max(groupedRelated.Incident.length - VISIBLE_INCIDENT_LIMIT, 0) +
       groupedRelated.Product.length +
       groupedRelated.ProductLine.length;
+    const incidentCount = groupedRelated.Incident.length;
+    const hasActiveIncidents = groupedRelated.Incident.some(isActiveIncident);
     return {
       topMatch,
       groupedRelated,
       hiddenRelatedPagesCount,
       companyMatch,
+      incidentCount,
+      hasActiveIncidents,
     };
   }, [matches]);
 
   if (!derived.topMatch) return null;
+
+  // Render minimized view
+  if (isMinimized) {
+    return (
+      <div
+        style={{
+          ...POPUP_LAYOUT.root,
+          ...containerStyle,
+          width: "auto",
+          minWidth: "120px",
+          maxWidth: "200px",
+        }}
+      >
+        <MinimizedView
+          logoUrl={logoUrl}
+          incidentCount={derived.incidentCount}
+          hasActiveIncidents={derived.hasActiveIncidents}
+          onExpand={onToggleMinimize || (() => {})}
+        />
+      </div>
+    );
+  }
 
   const visibleIncidents = derived.groupedRelated.Incident.slice(
     0,
@@ -263,6 +354,7 @@ export const MatchPopupCard = (props: MatchPopupCardProps) => {
         closeIconUrl={closeIconUrl}
         showCloseButton={showCloseButton}
         onClose={onClose}
+        onToggleMinimize={onToggleMinimize}
       />
 
       <MatchPopupBody

--- a/src/shared/ui/MatchPopupHeader.tsx
+++ b/src/shared/ui/MatchPopupHeader.tsx
@@ -14,6 +14,7 @@ type MatchPopupHeaderProps = {
   closeIconUrl?: string;
   showCloseButton?: boolean;
   onClose?: () => void;
+  onToggleMinimize?: () => void;
 };
 
 export const MatchPopupHeader = (props: MatchPopupHeaderProps) => {
@@ -25,11 +26,14 @@ export const MatchPopupHeader = (props: MatchPopupHeaderProps) => {
     closeIconUrl,
     showCloseButton = false,
     onClose,
+    onToggleMinimize,
   } = props;
 
   const canShowSettingsButton = !!onOpenSettings && !!settingsIconUrl;
   const canShowCloseButton = showCloseButton && !!onClose && !!closeIconUrl;
-  const showHeaderActions = canShowSettingsButton || canShowCloseButton;
+  const canShowMinimizeButton = !!onToggleMinimize;
+  const showHeaderActions =
+    canShowSettingsButton || canShowCloseButton || canShowMinimizeButton;
   const headerRowStyle: React.CSSProperties = {
     ...POPUP_LAYOUT.headerRow,
     justifyContent: showHeaderActions ? "space-between" : "flex-start",
@@ -115,11 +119,39 @@ export const MatchPopupHeader = (props: MatchPopupHeaderProps) => {
               />
             </button>
           )}
+          {canShowMinimizeButton && (
+            <button
+              type="button"
+              onClick={onToggleMinimize}
+              {...ghostButtonHoverHandlers}
+              aria-label="Minimize popup"
+              title="Minimize"
+              style={headerIconButtonStyle}
+            >
+              <span
+                style={{
+                  fontSize: "18px",
+                  fontWeight: 700,
+                  color: POPUP_CSS.muted,
+                  lineHeight: 1,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  width: "18px",
+                  height: "18px",
+                }}
+              >
+                −
+              </span>
+            </button>
+          )}
           {canShowCloseButton && (
             <button
               type="button"
               onClick={onClose}
               {...ghostButtonHoverHandlers}
+              aria-label="Close popup"
+              title="Close"
               style={{
                 ...headerIconButtonStyle,
               }}


### PR DESCRIPTION
## Summary
Adds a minimize/restore toggle button to the inline popup so users can collapse it to a small indicator instead of closing it completely.

## Problem
Users wanted the popup to be "less in your face" - sometimes they don't want to read it immediately but also don't want to close it entirely.

## Solution
- Added minimize button ("−") to the popup header
- When minimized, shows a compact indicator with logo + incident count
- Click the minimized indicator to expand back to full view
- Minimized state is NOT persisted (resets on page reload)
- Users can still close completely via X button

## Changes

### InlinePopup.tsx
- Added `isMinimized` state with `useState`
- Added `handleToggleMinimize` function
- Pass `isMinimized` and `onToggleMinimize` to MatchPopupCard

### MatchPopupCard.tsx
- Added new props: `isMinimized?: boolean` and `onToggleMinimize?: () => void`
- Created `MinimizedView` component with:
  - Logo icon (32px)
  - Incident count badge (red for active, gray for none)
  - "▼" expand indicator
- When minimized, renders compact view (120-200px width)
- When expanded, shows full popup with minimize button

### MatchPopupHeader.tsx
- Added `onToggleMinimize?: () => void` prop
- Added minimize button using "−" character
- Button positioned between settings and close buttons
- Includes hover handlers and accessibility labels

## Visual Preview

### Full View
```
┌─────────────────────────────────┐
│ 🖼️ Consumer Rights Wiki   ⚙️ − ✕ │
├─────────────────────────────────┤
│ [Incident Summary]              │
│ [Company Info]                  │
│ [Related Incidents...]         │
└─────────────────────────────────┘
```

### Minimized View
```
┌──────────────┐
│ 🖼️  5 ▼      │
└──────────────┘
```

## Testing
- Build completes successfully for Chrome and Firefox
- Impact analysis shows LOW risk (leaf components)
- No breaking changes to existing functionality


# Screenshot

<img width="449" height="246" alt="image" src="https://github.com/user-attachments/assets/c295b29a-42af-4a88-96ec-74b27049ce13" />
<img width="175" height="68" alt="image" src="https://github.com/user-attachments/assets/10fff202-31a8-4c6b-b05b-0b0edcb27001" />
