### PR TITLE
Cross-TLD matching so it no longer treats arbitrary compound suffixes like axis.bank.in as aliases of axis.com

### DIFF
--- a/docs/MATCHING.md
+++ b/docs/MATCHING.md
@@ -5,7 +5,9 @@ The URL matcher behavior is controlled by the exported `matchingConfig` object i
 ### Top-level params
 
 - `enableSubdomainMatching` (`boolean`, default: `true`): allows matches when the visited URL and candidate URL share the same root domain but use different subdomains (for example `support.example.com` vs `example.com`). Produces a `subdomain` match.
-- `enableMatchAcrossTLDs` (`boolean`, default: `true`): allows cross-TLD alias matches for the same domain label when the suffix is compound and the registrable domains differ (for example `dyson.co.uk` vs `dyson.com.au`). Produces a `subdomain` match with a `cross_tld_alias` reason.
+- `enableMatchAcrossTLDs` (`boolean`, default: `true`): allows cross-TLD alias matches for the same domain label when the suffix shape is allowed by the configured cross-TLD alias rules and the registrable domains differ (for example `dyson.co.uk` vs `dyson.com.au`). Produces a `subdomain` match with a `cross_tld_alias` reason.
+- `crossTldAliasGlobalSuffixes` (`string[]`, default: `["com", "net", "org"]`): global suffixes that may pair with configured market-style ccTLD suffixes for cross-TLD alias matching.
+- `crossTldAliasMarketSecondLevelLabels` (`string[]`, default: `["ac", "co", "com", "edu", "net", "org"]`): second-level labels that are treated as market-style public suffix prefixes when followed by a two-letter country code (for example `co.uk`, `com.au`).
 - `enableEcommerceFamilyAliasMatching` (`boolean`, default: `true`): allows known ecommerce domains in the same configured family (Amazon, eBay, etc.) to match each other across country domains. Produces a `subdomain` match with an `ecommerce_family_alias` reason.
 - `restrictMetaPageContextToEcommerceHosts` (`boolean`, default: `true`): when enabled, title/meta/OG page-context seeds are only used on known ecommerce hosts. Set to `false` to allow those signals on non-ecommerce hosts when URL seeds exist.
 - `urlSeedLimit` (`number`, default: `3`): default limit intended for URL-seed matching workflows.
@@ -48,6 +50,6 @@ The URL matcher behavior is controlled by the exported `matchingConfig` object i
 
 ### Current usage notes
 
-- URL matching currently uses `enableSubdomainMatching`, `enableMatchAcrossTLDs`, `enableEcommerceFamilyAliasMatching`, `specificPathDomainMatches`, and `ecommerceDomainFamilyMap`.
+- URL matching currently uses `enableSubdomainMatching`, `enableMatchAcrossTLDs`, `crossTldAliasGlobalSuffixes`, `crossTldAliasMarketSecondLevelLabels`, `enableEcommerceFamilyAliasMatching`, `specificPathDomainMatches`, and `ecommerceDomainFamilyMap`.
 - `matchByPageContext(...)` currently reads `enableSearchResultsPageSuppressions`, `searchResultsPageSuppressions`, `restrictMetaPageContextToEcommerceHosts`, `companyAliasSuffixStripping`, `amazonPropertyMatching`, and `ebayJsonLdProductMatching` (along with related page-context matching logic).
 - The page-context and seed-limit params are defined in config now for matching/scoring workflows, but are not currently read by `src/lib/matching/urlMatching.ts`.

--- a/src/lib/matching/matchingConfig.ts
+++ b/src/lib/matching/matchingConfig.ts
@@ -29,6 +29,8 @@ export type EbayJsonLdProductMatchingConfig = {
 export type MatchingConfig = {
   enableSubdomainMatching: boolean;
   enableMatchAcrossTLDs: boolean;
+  crossTldAliasGlobalSuffixes: string[];
+  crossTldAliasMarketSecondLevelLabels: string[];
   enableEcommerceFamilyAliasMatching: boolean;
   restrictMetaPageContextToEcommerceHosts: boolean;
   urlSeedLimit: number;
@@ -64,6 +66,15 @@ export type MatchingConfig = {
 const DEFAULT_MATCHING_CONFIG: MatchingConfig = {
   enableSubdomainMatching: true,
   enableMatchAcrossTLDs: true,
+  crossTldAliasGlobalSuffixes: ["com", "net", "org"],
+  crossTldAliasMarketSecondLevelLabels: [
+    "ac",
+    "co",
+    "com",
+    "edu",
+    "net",
+    "org",
+  ],
   enableEcommerceFamilyAliasMatching: true,
   restrictMetaPageContextToEcommerceHosts: true,
   urlSeedLimit: 3,

--- a/src/lib/matching/urlMatching.ts
+++ b/src/lib/matching/urlMatching.ts
@@ -51,6 +51,45 @@ const getCrossTldAliasKey = (hostname: string): string | null => {
   return `${parsed.domainWithoutSuffix}|${parsed.publicSuffix}`;
 };
 
+const isLikelyMarketCountryCodeSuffix = (suffix: string): boolean => {
+  const parts = suffix.toLowerCase().split(".").filter(Boolean);
+  if (parts.length !== 2) return false;
+
+  const [secondLevel, countryCode] = parts;
+  const marketLabels = new Set(
+    matchingConfig.crossTldAliasMarketSecondLevelLabels.map((value) =>
+      value.toLowerCase(),
+    ),
+  );
+  return (
+    countryCode.length === 2 && marketLabels.has(secondLevel)
+  );
+};
+
+const isEligibleCrossTldAliasPair = (
+  visitedSuffix: string,
+  candidateSuffix: string,
+): boolean => {
+  const globalSuffixes = new Set(
+    matchingConfig.crossTldAliasGlobalSuffixes.map((value) =>
+      value.toLowerCase(),
+    ),
+  );
+  if (
+    isLikelyMarketCountryCodeSuffix(visitedSuffix) &&
+    isLikelyMarketCountryCodeSuffix(candidateSuffix)
+  ) {
+    return true;
+  }
+
+  return (
+    (isLikelyMarketCountryCodeSuffix(visitedSuffix) &&
+      globalSuffixes.has(candidateSuffix)) ||
+    (isLikelyMarketCountryCodeSuffix(candidateSuffix) &&
+      globalSuffixes.has(visitedSuffix))
+  );
+};
+
 const normalizeMatchHostname = (hostname: string): string => {
   return hostname.toLowerCase().replace(/^www\./, "");
 };
@@ -121,15 +160,13 @@ export const classifyUrlMatch = (
     const [visitedLabel, visitedSuffix] = visitedAliasKey?.split("|") ?? [];
     const [candidateLabel, candidateSuffix] =
       candidateAliasKey?.split("|") ?? [];
-    const hasCompoundSuffix =
-      Boolean(visitedSuffix?.includes(".")) ||
-      Boolean(candidateSuffix?.includes("."));
-
     if (
       visitedLabel &&
       candidateLabel &&
+      visitedSuffix &&
+      candidateSuffix &&
       visitedLabel === candidateLabel &&
-      hasCompoundSuffix &&
+      isEligibleCrossTldAliasPair(visitedSuffix, candidateSuffix) &&
       visitedRoot !== candidateRoot
     ) {
       return {

--- a/src/lib/matching/urlMatching.ts
+++ b/src/lib/matching/urlMatching.ts
@@ -61,9 +61,7 @@ const isLikelyMarketCountryCodeSuffix = (suffix: string): boolean => {
       value.toLowerCase(),
     ),
   );
-  return (
-    countryCode.length === 2 && marketLabels.has(secondLevel)
-  );
+  return countryCode.length === 2 && marketLabels.has(secondLevel);
 };
 
 const isEligibleCrossTldAliasPair = (

--- a/tests/urlMatching.test.ts
+++ b/tests/urlMatching.test.ts
@@ -242,6 +242,52 @@ test("does not classify unrelated .com.au domains as subdomain matches", () => {
   assert.equal(result, null);
 });
 
+test("does not treat compound brand domains like axis.bank.in as axis.com aliases", () => {
+  setMatchingConfig({
+    enableMatchAcrossTLDs: true,
+    enableSubdomainMatching: true,
+  });
+  const visited = safeParseUrl("https://www.axis.bank.in/");
+  const candidate = safeParseUrl("https://axis.com/");
+  assert.ok(visited);
+  assert.ok(candidate);
+
+  const result = classifyUrlMatch(visited, candidate);
+  assert.equal(result, null);
+});
+
+test("does not treat gov.uk domains as consumer-market aliases of .com", () => {
+  setMatchingConfig({
+    enableMatchAcrossTLDs: true,
+    enableSubdomainMatching: true,
+  });
+  const visited = safeParseUrl("https://www.acme.gov.uk/");
+  const candidate = safeParseUrl("https://acme.com/");
+  assert.ok(visited);
+  assert.ok(candidate);
+
+  const result = classifyUrlMatch(visited, candidate);
+  assert.equal(result, null);
+});
+
+test("cross-TLD alias market suffixes are configurable", () => {
+  setMatchingConfig({
+    enableMatchAcrossTLDs: true,
+    enableSubdomainMatching: true,
+    crossTldAliasMarketSecondLevelLabels: ["gov"],
+    crossTldAliasGlobalSuffixes: ["com"],
+  });
+  const visited = safeParseUrl("https://www.acme.gov.uk/");
+  const candidate = safeParseUrl("https://acme.com/");
+  assert.ok(visited);
+  assert.ok(candidate);
+
+  const result = classifyUrlMatch(visited, candidate);
+  assert.ok(result);
+  assert.equal(result.matchType, "subdomain");
+  assert.equal(result.crossTldAlias, true);
+});
+
 test("classifies .co.uk subdomains using registrable domain", () => {
   setMatchingConfig({ enableSubdomainMatching: true });
   const visited = safeParseUrl("https://support.bbc.co.uk/help");


### PR DESCRIPTION
It only allows explicitly configured market-style suffix patterns such as co.uk or com.au

Fixes https://github.com/FULU-Foundation/CRW-Extension/issues/77