### PR TITLE
Add homepage URL to firefox.json

### DIFF
--- a/manifest/firefox.json
+++ b/manifest/firefox.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "author": "jake@fulu.org",
   "description": "Shows a popup and notifications when the current site may have an article on the Consumer Rights Wiki.",
+  "homepage_url": "https://github.com/FULU-Foundation/CRW-Extension",
   "action": {
     "default_title": "CRW Extension",
     "default_icon": {


### PR DESCRIPTION
Add homepage URL to the Firefox manifest file.
Closes #111