### PR TITLE
Snooze until new incidents

### DIFF
--- a/src/content/InlinePopup.tsx
+++ b/src/content/InlinePopup.tsx
@@ -15,7 +15,9 @@ type InlinePopupProps = {
   onSnoozeUntilNewChanges?: () => void;
   onDisableWarnings?: () => void;
   snoozeUntilNewChangesLabel?: string;
+  snoozeUntilNewChangesTooltip?: string;
   suppressButtonLabel?: string;
+  suppressButtonTooltip?: string;
   disableWarningsLabel?: string;
 };
 
@@ -32,7 +34,9 @@ export const InlinePopup = (props: InlinePopupProps) => {
     onSnoozeUntilNewChanges,
     onDisableWarnings,
     snoozeUntilNewChangesLabel,
+    snoozeUntilNewChangesTooltip,
     suppressButtonLabel,
+    suppressButtonTooltip,
     disableWarningsLabel,
   } = props;
 
@@ -49,7 +53,9 @@ export const InlinePopup = (props: InlinePopupProps) => {
       onSnoozeUntilNewChanges={onSnoozeUntilNewChanges}
       onDisableWarnings={onDisableWarnings}
       snoozeUntilNewChangesLabel={snoozeUntilNewChangesLabel}
+      snoozeUntilNewChangesTooltip={snoozeUntilNewChangesTooltip}
       suppressButtonLabel={suppressButtonLabel}
+      suppressButtonTooltip={suppressButtonTooltip}
       disableWarningsLabel={disableWarningsLabel}
       showCloseButton
       hideRelatedButtonWhenEmpty

--- a/src/content/InlinePopup.tsx
+++ b/src/content/InlinePopup.tsx
@@ -12,9 +12,9 @@ type InlinePopupProps = {
   onClose: () => void;
   onOpenSettings: () => void;
   onSuppressSite: () => void;
-  onSuppressPageName?: () => void;
+  onSnoozeUntilNewChanges?: () => void;
   onDisableWarnings?: () => void;
-  suppressPageNameLabel?: string;
+  snoozeUntilNewChangesLabel?: string;
   suppressButtonLabel?: string;
   disableWarningsLabel?: string;
 };
@@ -29,9 +29,9 @@ export const InlinePopup = (props: InlinePopupProps) => {
     onClose,
     onOpenSettings,
     onSuppressSite,
-    onSuppressPageName,
+    onSnoozeUntilNewChanges,
     onDisableWarnings,
-    suppressPageNameLabel,
+    snoozeUntilNewChangesLabel,
     suppressButtonLabel,
     disableWarningsLabel,
   } = props;
@@ -46,9 +46,9 @@ export const InlinePopup = (props: InlinePopupProps) => {
       settingsIconUrl={settingsIconUrl}
       closeIconUrl={closeIconUrl}
       onSuppressSite={onSuppressSite}
-      onSuppressPageName={onSuppressPageName}
+      onSnoozeUntilNewChanges={onSnoozeUntilNewChanges}
       onDisableWarnings={onDisableWarnings}
-      suppressPageNameLabel={suppressPageNameLabel}
+      snoozeUntilNewChangesLabel={snoozeUntilNewChangesLabel}
       suppressButtonLabel={suppressButtonLabel}
       disableWarningsLabel={disableWarningsLabel}
       showCloseButton

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -3,6 +3,11 @@ import { createRoot, type Root } from "react-dom/client";
 import browser from "webextension-polyfill";
 
 import * as Constants from "@/shared/constants";
+import { buildIncidentSignature } from "@/shared/incidentSignature";
+import {
+  type SnoozedSiteMap,
+  normalizeSnoozedSiteMap,
+} from "@/shared/snoozedSites";
 import { CargoEntry, PageContext } from "@/shared/types";
 import * as Messaging from "@/messaging";
 import { MessageType } from "@/messaging/type";
@@ -34,6 +39,7 @@ let popupHost: HTMLDivElement | null = null;
 let popupShadowMount: HTMLDivElement | null = null;
 let popupRoot: Root | null = null;
 let forcePopupVisible = false;
+const SNOOZE_UNTIL_NEW_CHANGES_LABEL = "Snooze until new changes";
 
 const normalizeHostname = (hostname: string): string => {
   return hostname
@@ -60,41 +66,62 @@ const isCurrentSiteSuppressed = async (): Promise<boolean> => {
   return current.length > 0 && domains.includes(current);
 };
 
-const normalizePageName = (pageName: string): string => {
-  return pageName.trim().toLowerCase();
-};
-
-const getSuppressedPageNames = async (): Promise<string[]> => {
+const readSnoozedSiteMap = async (): Promise<SnoozedSiteMap> => {
   const stored = await browser.storage.local.get(
-    Constants.STORAGE.SUPPRESSED_PAGE_NAMES,
+    Constants.STORAGE.SNOOZED_SITES_UNTIL_INCIDENT_CHANGE,
   );
-  const value = stored[Constants.STORAGE.SUPPRESSED_PAGE_NAMES];
-  if (!Array.isArray(value)) return [];
-  return value
-    .filter((entry): entry is string => typeof entry === "string")
-    .map((entry) => entry.trim())
-    .filter((entry) => entry.length > 0);
+  return normalizeSnoozedSiteMap(
+    stored[
+      Constants.STORAGE.SNOOZED_SITES_UNTIL_INCIDENT_CHANGE
+    ] as SnoozedSiteMap | undefined,
+  );
 };
 
-const suppressPageName = async (pageName: string): Promise<void> => {
-  const trimmed = pageName.trim();
-  const normalized = normalizePageName(pageName);
-  if (!normalized) return;
-  const names = await getSuppressedPageNames();
-  if (names.some((name) => normalizePageName(name) === normalized)) return;
+const writeSnoozedSiteMap = async (next: SnoozedSiteMap): Promise<void> => {
   await browser.storage.local.set({
-    [Constants.STORAGE.SUPPRESSED_PAGE_NAMES]: [...names, trimmed],
+    [Constants.STORAGE.SNOOZED_SITES_UNTIL_INCIDENT_CHANGE]: next,
   });
 };
 
-const unsuppressPageName = async (pageName: string): Promise<void> => {
-  const normalized = normalizePageName(pageName);
-  if (!normalized) return;
-  const names = await getSuppressedPageNames();
-  const next = names.filter((name) => normalizePageName(name) !== normalized);
-  await browser.storage.local.set({
-    [Constants.STORAGE.SUPPRESSED_PAGE_NAMES]: next,
-  });
+const isHideWhenNoIncidentsEnabled = async (): Promise<boolean> => {
+  const stored = await browser.storage.local.get(
+    Constants.STORAGE.HIDE_WHEN_NO_INCIDENTS,
+  );
+  const value = stored[Constants.STORAGE.HIDE_WHEN_NO_INCIDENTS];
+  if (typeof value === "boolean") return value;
+  return true;
+};
+
+const snoozeCurrentSiteUntilNewIncidentChanges = async (
+  incidentSignature: string,
+): Promise<void> => {
+  const current = normalizeHostname(location.hostname || "");
+  if (!current) return;
+  const snoozedSiteMap = await readSnoozedSiteMap();
+  snoozedSiteMap[current] = {
+    incidentSignature,
+    snoozedAt: Date.now(),
+  };
+  await writeSnoozedSiteMap(snoozedSiteMap);
+};
+
+const isCurrentSiteSnoozedUntilIncidentChanges = async (
+  incidentSignature: string,
+): Promise<boolean> => {
+  const current = normalizeHostname(location.hostname || "");
+  if (!current) return false;
+
+  const snoozedSiteMap = await readSnoozedSiteMap();
+  const state = snoozedSiteMap[current];
+  if (!state) return false;
+
+  if (state.incidentSignature === incidentSignature) {
+    return true;
+  }
+
+  delete snoozedSiteMap[current];
+  await writeSnoozedSiteMap(snoozedSiteMap);
+  return false;
 };
 
 const isWarningsEnabled = async (): Promise<boolean> => {
@@ -221,44 +248,7 @@ const renderInlinePopup = async (
   matches: CargoEntry[],
   ignorePreferences = false,
 ) => {
-  const suppressedPageNames = await getSuppressedPageNames();
-  const suppressedPageNameSet = new Set(
-    suppressedPageNames.map((name) => normalizePageName(name)),
-  );
-  const filteredMatches =
-    suppressedPageNameSet.size === 0
-      ? matches
-      : matches.filter((match) => {
-          const normalizedPageName = normalizePageName(
-            String(match.PageName || ""),
-          );
-          if (suppressedPageNameSet.has(normalizedPageName)) return false;
-
-          if (
-            match._type === "Product" ||
-            match._type === "ProductLine" ||
-            match._type === "Incident"
-          ) {
-            const normalizedCompany = normalizePageName(
-              String(match.Company || ""),
-            );
-            if (
-              normalizedCompany &&
-              suppressedPageNameSet.has(normalizedCompany)
-            ) {
-              return false;
-            }
-          }
-
-          return true;
-        });
-
-  const visibleMatches = ignorePreferences ? matches : filteredMatches;
-
-  if (visibleMatches.length === 0 && !ignorePreferences) {
-    removeInlinePopup();
-    return;
-  }
+  const visibleMatches = matches;
 
   const currentlyWarningsEnabled = await isWarningsEnabled();
 
@@ -272,6 +262,28 @@ const renderInlinePopup = async (
     removeInlinePopup();
     return;
   }
+
+  const hideWhenNoIncidents = await isHideWhenNoIncidentsEnabled();
+  const incidentSignature = buildIncidentSignature(visibleMatches);
+  const hasIncidents = incidentSignature.length > 0;
+  if (!ignorePreferences && hideWhenNoIncidents && !hasIncidents) {
+    removeInlinePopup();
+    return;
+  }
+
+  const currentlySnoozed = await isCurrentSiteSnoozedUntilIncidentChanges(
+    incidentSignature,
+  );
+  if (!ignorePreferences && currentlySnoozed) {
+    removeInlinePopup();
+    return;
+  }
+
+  if (visibleMatches.length === 0 && !ignorePreferences) {
+    removeInlinePopup();
+    return;
+  }
+
   forcePopupVisible = ignorePreferences;
   const root = ensurePopupRoot();
   if (visibleMatches.length === 0) {
@@ -297,65 +309,6 @@ const renderInlinePopup = async (
     removeInlinePopup();
   };
 
-  const topVisibleMatch = visibleMatches[0];
-  const topVisiblePageName = String(topVisibleMatch?.PageName || "").trim();
-  const topVisiblePageNameNormalized = normalizePageName(topVisiblePageName);
-  const topVisibleCompanyName = String(topVisibleMatch?.Company || "").trim();
-  const topVisibleCompanyNormalized = normalizePageName(topVisibleCompanyName);
-  const topVisibleScopeType = topVisibleMatch?._type;
-  const topVisibleTypeUsesCompanyToggle =
-    topVisibleScopeType === "Product" ||
-    topVisibleScopeType === "ProductLine" ||
-    topVisibleScopeType === "Incident";
-  const topVisiblePageSuppressed =
-    Boolean(topVisiblePageNameNormalized) &&
-    suppressedPageNameSet.has(topVisiblePageNameNormalized);
-  const topVisibleCompanySuppressed =
-    topVisibleTypeUsesCompanyToggle &&
-    Boolean(topVisibleCompanyNormalized) &&
-    suppressedPageNameSet.has(topVisibleCompanyNormalized);
-
-  const getSuppressPageNameAction = () => {
-    if (
-      ignorePreferences &&
-      topVisibleCompanySuppressed &&
-      topVisibleCompanyName
-    ) {
-      return {
-        label: "Show this company",
-        run: async () => {
-          await unsuppressPageName(topVisibleCompanyName);
-          void renderInlinePopup(matches, true);
-        },
-      };
-    }
-
-    if (ignorePreferences && topVisiblePageSuppressed && topVisibleMatch) {
-      const scope =
-        topVisibleMatch._type === "ProductLine"
-          ? "product"
-          : topVisibleMatch._type.toLowerCase();
-      return {
-        label: `Show this ${scope}`,
-        run: async () => {
-          await unsuppressPageName(topVisiblePageName);
-          void renderInlinePopup(matches, true);
-        },
-      };
-    }
-
-    return {
-      label: undefined,
-      run: async () => {
-        if (!topVisiblePageName) return;
-        await suppressPageName(topVisiblePageName);
-        void renderInlinePopup(matches, ignorePreferences);
-      },
-    };
-  };
-
-  const suppressPageNameAction = getSuppressPageNameAction();
-
   const handleSuppressSiteClick = async () => {
     if (ignorePreferences && currentlySuppressed) {
       await unsuppressCurrentSite();
@@ -364,6 +317,11 @@ const renderInlinePopup = async (
     }
 
     await suppressCurrentSite();
+    removeInlinePopup();
+  };
+
+  const handleSnoozeUntilNewChangesClick = async () => {
+    await snoozeCurrentSiteUntilNewIncidentChanges(incidentSignature);
     removeInlinePopup();
   };
 
@@ -387,8 +345,8 @@ const renderInlinePopup = async (
           ? "Show this site"
           : "Hide for this site"
       }
-      suppressPageNameLabel={suppressPageNameAction.label}
-      onSuppressPageName={() => void suppressPageNameAction.run()}
+      snoozeUntilNewChangesLabel={SNOOZE_UNTIL_NEW_CHANGES_LABEL}
+      onSnoozeUntilNewChanges={() => void handleSnoozeUntilNewChangesClick()}
       onSuppressSite={() => void handleSuppressSiteClick()}
     />,
   );
@@ -492,7 +450,10 @@ browser.storage.onChanged.addListener((changes, areaName) => {
     ) {
       removeInlinePopup();
     }
-    if (changes[Constants.STORAGE.SUPPRESSED_PAGE_NAMES]) {
+    if (
+      changes[Constants.STORAGE.SNOOZED_SITES_UNTIL_INCIDENT_CHANGE] ||
+      changes[Constants.STORAGE.HIDE_WHEN_NO_INCIDENTS]
+    ) {
       void runContentScript();
     }
   };

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -39,7 +39,7 @@ let popupHost: HTMLDivElement | null = null;
 let popupShadowMount: HTMLDivElement | null = null;
 let popupRoot: Root | null = null;
 let forcePopupVisible = false;
-const SNOOZE_UNTIL_NEW_CHANGES_LABEL = "Snooze until new changes";
+const SNOOZE_UNTIL_NEW_CHANGES_LABEL = "Hide until new incidents";
 
 const normalizeHostname = (hostname: string): string => {
   return hostname
@@ -97,11 +97,28 @@ const snoozeCurrentSiteUntilNewIncidentChanges = async (
 ): Promise<void> => {
   const current = normalizeHostname(location.hostname || "");
   if (!current) return;
+  const domains = await getSuppressedDomains();
+  if (domains.includes(current)) {
+    await browser.storage.local.set({
+      [Constants.STORAGE.SUPPRESSED_DOMAINS]: domains.filter(
+        (domain) => domain !== current,
+      ),
+    });
+  }
   const snoozedSiteMap = await readSnoozedSiteMap();
   snoozedSiteMap[current] = {
     incidentSignature,
     snoozedAt: Date.now(),
   };
+  await writeSnoozedSiteMap(snoozedSiteMap);
+};
+
+const unsnoozeCurrentSiteUntilNewIncidentChanges = async (): Promise<void> => {
+  const current = normalizeHostname(location.hostname || "");
+  if (!current) return;
+  const snoozedSiteMap = await readSnoozedSiteMap();
+  if (!snoozedSiteMap[current]) return;
+  delete snoozedSiteMap[current];
   await writeSnoozedSiteMap(snoozedSiteMap);
 };
 
@@ -177,10 +194,12 @@ const suppressCurrentSite = async (): Promise<void> => {
   const current = normalizeHostname(location.hostname || "");
   if (!current) return;
   const domains = await getSuppressedDomains();
-  if (domains.includes(current)) return;
-  await browser.storage.local.set({
-    [Constants.STORAGE.SUPPRESSED_DOMAINS]: [...domains, current],
-  });
+  if (!domains.includes(current)) {
+    await browser.storage.local.set({
+      [Constants.STORAGE.SUPPRESSED_DOMAINS]: [...domains, current],
+    });
+  }
+  await unsnoozeCurrentSiteUntilNewIncidentChanges();
 };
 
 const unsuppressCurrentSite = async (): Promise<void> => {
@@ -258,9 +277,12 @@ const renderInlinePopup = async (
   }
 
   const currentlySuppressed = await isCurrentSiteSuppressed();
-  if (!ignorePreferences && currentlySuppressed) {
-    removeInlinePopup();
-    return;
+  if (currentlySuppressed) {
+    await unsnoozeCurrentSiteUntilNewIncidentChanges();
+    if (!ignorePreferences) {
+      removeInlinePopup();
+      return;
+    }
   }
 
   const hideWhenNoIncidents = await isHideWhenNoIncidentsEnabled();
@@ -271,8 +293,9 @@ const renderInlinePopup = async (
     return;
   }
 
-  const currentlySnoozed =
-    await isCurrentSiteSnoozedUntilIncidentChanges(incidentSignature);
+  const currentlySnoozed = currentlySuppressed
+    ? false
+    : await isCurrentSiteSnoozedUntilIncidentChanges(incidentSignature);
   if (!ignorePreferences && currentlySnoozed) {
     removeInlinePopup();
     return;
@@ -320,6 +343,12 @@ const renderInlinePopup = async (
   };
 
   const handleSnoozeUntilNewChangesClick = async () => {
+    if (currentlySnoozed) {
+      await unsnoozeCurrentSiteUntilNewIncidentChanges();
+      void renderInlinePopup(matches, true);
+      return;
+    }
+
     await snoozeCurrentSiteUntilNewIncidentChanges(incidentSignature);
     removeInlinePopup();
   };
@@ -341,11 +370,33 @@ const renderInlinePopup = async (
       }
       suppressButtonLabel={
         ignorePreferences && currentlySuppressed
-          ? "Show this site"
-          : "Hide for this site"
+          ? "Always show for this site"
+          : "Always hide for this site"
       }
-      snoozeUntilNewChangesLabel={SNOOZE_UNTIL_NEW_CHANGES_LABEL}
-      onSnoozeUntilNewChanges={() => void handleSnoozeUntilNewChangesClick()}
+      suppressButtonTooltip={
+        ignorePreferences && currentlySuppressed
+          ? "Show alerts for this site again."
+          : "Hide alerts for this site until you choose to show them again."
+      }
+      snoozeUntilNewChangesLabel={
+        currentlySuppressed
+          ? undefined
+          : currentlySnoozed
+            ? "Resume alerts"
+            : SNOOZE_UNTIL_NEW_CHANGES_LABEL
+      }
+      snoozeUntilNewChangesTooltip={
+        currentlySuppressed
+          ? undefined
+          : currentlySnoozed
+            ? "Turn alerts back on for this site."
+            : "Hide alerts until there are new incidents."
+      }
+      onSnoozeUntilNewChanges={
+        currentlySuppressed
+          ? undefined
+          : () => void handleSnoozeUntilNewChangesClick()
+      }
       onSuppressSite={() => void handleSuppressSiteClick()}
     />,
   );

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -71,9 +71,9 @@ const readSnoozedSiteMap = async (): Promise<SnoozedSiteMap> => {
     Constants.STORAGE.SNOOZED_SITES_UNTIL_INCIDENT_CHANGE,
   );
   return normalizeSnoozedSiteMap(
-    stored[
-      Constants.STORAGE.SNOOZED_SITES_UNTIL_INCIDENT_CHANGE
-    ] as SnoozedSiteMap | undefined,
+    stored[Constants.STORAGE.SNOOZED_SITES_UNTIL_INCIDENT_CHANGE] as
+      | SnoozedSiteMap
+      | undefined,
   );
 };
 
@@ -271,9 +271,8 @@ const renderInlinePopup = async (
     return;
   }
 
-  const currentlySnoozed = await isCurrentSiteSnoozedUntilIncidentChanges(
-    incidentSignature,
-  );
+  const currentlySnoozed =
+    await isCurrentSiteSnoozedUntilIncidentChanges(incidentSignature);
   if (!ignorePreferences && currentlySnoozed) {
     removeInlinePopup();
     return;

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -5,6 +5,10 @@ import * as Constants from "@/shared/constants";
 import { OptionsView } from "@/options/OptionsView";
 import * as Messaging from "@/messaging";
 import { MessageType } from "@/messaging/type";
+import {
+  type SnoozedSiteMap,
+  normalizeSnoozedSiteMap,
+} from "@/shared/snoozedSites";
 
 const readWarningsEnabled = async (): Promise<boolean> => {
   const stored = await browser.storage.local.get(
@@ -34,20 +38,24 @@ const readSuppressedDomains = async (): Promise<string[]> => {
     .filter((entry) => entry.length > 0);
 };
 
-const normalizePageName = (pageName: string): string => {
-  return pageName.trim().toLowerCase();
+const readHideWhenNoIncidents = async (): Promise<boolean> => {
+  const stored = await browser.storage.local.get(
+    Constants.STORAGE.HIDE_WHEN_NO_INCIDENTS,
+  );
+  const value = stored[Constants.STORAGE.HIDE_WHEN_NO_INCIDENTS];
+  if (typeof value === "boolean") return value;
+  return true;
 };
 
-const readSuppressedPageNames = async (): Promise<string[]> => {
+const readSnoozedSiteMap = async (): Promise<SnoozedSiteMap> => {
   const stored = await browser.storage.local.get(
-    Constants.STORAGE.SUPPRESSED_PAGE_NAMES,
+    Constants.STORAGE.SNOOZED_SITES_UNTIL_INCIDENT_CHANGE,
   );
-  const value = stored[Constants.STORAGE.SUPPRESSED_PAGE_NAMES];
-  if (!Array.isArray(value)) return [];
-  return value
-    .filter((entry): entry is string => typeof entry === "string")
-    .map((entry) => entry.trim())
-    .filter((entry) => entry.length > 0);
+  return normalizeSnoozedSiteMap(
+    stored[
+      Constants.STORAGE.SNOOZED_SITES_UNTIL_INCIDENT_CHANGE
+    ] as SnoozedSiteMap | undefined,
+  );
 };
 
 const writeSuppressedDomains = async (domains: string[]): Promise<void> => {
@@ -56,10 +64,18 @@ const writeSuppressedDomains = async (domains: string[]): Promise<void> => {
   });
 };
 
-const writeSuppressedPageNames = async (pageNames: string[]): Promise<void> => {
+const writeSnoozedSiteMap = async (value: SnoozedSiteMap): Promise<void> => {
   await browser.storage.local.set({
-    [Constants.STORAGE.SUPPRESSED_PAGE_NAMES]: pageNames,
+    [Constants.STORAGE.SNOOZED_SITES_UNTIL_INCIDENT_CHANGE]: value,
   });
+};
+
+const readSnoozedSites = async (): Promise<string[]> => {
+  const value = await readSnoozedSiteMap();
+  return Object.keys(value)
+    .map((domain) => normalizeHostname(domain))
+    .filter((domain) => domain.length > 0)
+    .sort((left, right) => left.localeCompare(right));
 };
 
 const readRefreshIntervalMs = async (): Promise<number> => {
@@ -102,8 +118,9 @@ const readLastRefreshError = async (): Promise<string | null> => {
 
 const Options = () => {
   const [warningsEnabled, setWarningsEnabled] = useState<boolean>(true);
+  const [hideWhenNoIncidents, setHideWhenNoIncidents] = useState<boolean>(true);
   const [suppressedDomains, setSuppressedDomains] = useState<string[]>([]);
-  const [suppressedPageNames, setSuppressedPageNames] = useState<string[]>([]);
+  const [snoozedSites, setSnoozedSites] = useState<string[]>([]);
   const [refreshIntervalMs, setRefreshIntervalMs] = useState<number>(
     Constants.DEFAULT_DATA_REFRESH_INTERVAL_MS,
   );
@@ -118,22 +135,25 @@ const Options = () => {
       try {
         const [
           enabled,
+          hideWithoutIncidents,
           domains,
-          pageNames,
+          snoozedSiteDomains,
           intervalMs,
           refreshedAt,
           fetchError,
         ] = await Promise.all([
           readWarningsEnabled(),
+          readHideWhenNoIncidents(),
           readSuppressedDomains(),
-          readSuppressedPageNames(),
+          readSnoozedSites(),
           readRefreshIntervalMs(),
           readLastRefreshedAt(),
           readLastRefreshError(),
         ]);
         setWarningsEnabled(enabled);
+        setHideWhenNoIncidents(hideWithoutIncidents);
         setSuppressedDomains(domains);
-        setSuppressedPageNames(pageNames);
+        setSnoozedSites(snoozedSiteDomains);
         setRefreshIntervalMs(intervalMs);
         setLastRefreshedAt(refreshedAt);
         setLastRefreshError(fetchError);
@@ -181,6 +201,27 @@ const Options = () => {
           typeof nextError?.message === "string" ? nextError.message : null,
         );
       }
+
+      if (changes[Constants.STORAGE.HIDE_WHEN_NO_INCIDENTS]) {
+        const nextValue = changes[Constants.STORAGE.HIDE_WHEN_NO_INCIDENTS]
+          .newValue;
+        setHideWhenNoIncidents(
+          typeof nextValue === "boolean" ? nextValue : true,
+        );
+      }
+
+      if (changes[Constants.STORAGE.SNOOZED_SITES_UNTIL_INCIDENT_CHANGE]) {
+        const nextValue = normalizeSnoozedSiteMap(
+          changes[Constants.STORAGE.SNOOZED_SITES_UNTIL_INCIDENT_CHANGE]
+            .newValue as SnoozedSiteMap | undefined,
+        );
+        setSnoozedSites(
+          Object.keys(nextValue)
+            .map((domain) => normalizeHostname(domain))
+            .filter((domain) => domain.length > 0)
+            .sort((left, right) => left.localeCompare(right)),
+        );
+      }
     };
 
     browser.storage.onChanged.addListener(onStorageChanged);
@@ -203,13 +244,28 @@ const Options = () => {
     await writeSuppressedDomains(next);
   };
 
-  const onRemoveSuppressedPageName = async (pageName: string) => {
-    const normalized = normalizePageName(pageName);
-    const next = suppressedPageNames.filter(
-      (value) => normalizePageName(value) !== normalized,
+  const onToggleHideWhenNoIncidents = async (enabled: boolean) => {
+    setHideWhenNoIncidents(enabled);
+    await browser.storage.local.set({
+      [Constants.STORAGE.HIDE_WHEN_NO_INCIDENTS]: enabled,
+    });
+  };
+
+  const onRemoveSnoozedSite = async (domain: string) => {
+    const normalized = normalizeHostname(domain);
+    if (!normalized) return;
+
+    const existing = await readSnoozedSiteMap();
+    if (!Object.prototype.hasOwnProperty.call(existing, normalized)) return;
+    const next = { ...existing };
+    delete next[normalized];
+    setSnoozedSites(
+      Object.keys(next)
+        .map((value) => normalizeHostname(value))
+        .filter((value) => value.length > 0)
+        .sort((left, right) => left.localeCompare(right)),
     );
-    setSuppressedPageNames(next);
-    await writeSuppressedPageNames(next);
+    await writeSnoozedSiteMap(next);
   };
 
   const onChangeRefreshInterval = async (nextRefreshIntervalMs: number) => {
@@ -248,8 +304,9 @@ const Options = () => {
   return (
     <OptionsView
       warningsEnabled={warningsEnabled}
+      hideWhenNoIncidents={hideWhenNoIncidents}
       suppressedDomains={suppressedDomains}
-      suppressedPageNames={suppressedPageNames}
+      snoozedSites={snoozedSites}
       refreshIntervalMs={refreshIntervalMs}
       lastRefreshedAt={lastRefreshedAt}
       refreshingNow={refreshingNow}
@@ -258,6 +315,9 @@ const Options = () => {
       loading={loading}
       onToggleWarnings={(enabled) => {
         void onToggleWarnings(enabled);
+      }}
+      onToggleHideWhenNoIncidents={(enabled) => {
+        void onToggleHideWhenNoIncidents(enabled);
       }}
       onChangeRefreshInterval={(nextRefreshIntervalMs) => {
         void onChangeRefreshInterval(nextRefreshIntervalMs);
@@ -268,8 +328,8 @@ const Options = () => {
       onRemoveSuppressedDomain={(domain) => {
         void onRemoveSuppressedDomain(domain);
       }}
-      onRemoveSuppressedPageName={(pageName) => {
-        void onRemoveSuppressedPageName(pageName);
+      onRemoveSnoozedSite={(domain) => {
+        void onRemoveSnoozedSite(domain);
       }}
     />
   );

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -52,9 +52,9 @@ const readSnoozedSiteMap = async (): Promise<SnoozedSiteMap> => {
     Constants.STORAGE.SNOOZED_SITES_UNTIL_INCIDENT_CHANGE,
   );
   return normalizeSnoozedSiteMap(
-    stored[
-      Constants.STORAGE.SNOOZED_SITES_UNTIL_INCIDENT_CHANGE
-    ] as SnoozedSiteMap | undefined,
+    stored[Constants.STORAGE.SNOOZED_SITES_UNTIL_INCIDENT_CHANGE] as
+      | SnoozedSiteMap
+      | undefined,
   );
 };
 
@@ -203,8 +203,8 @@ const Options = () => {
       }
 
       if (changes[Constants.STORAGE.HIDE_WHEN_NO_INCIDENTS]) {
-        const nextValue = changes[Constants.STORAGE.HIDE_WHEN_NO_INCIDENTS]
-          .newValue;
+        const nextValue =
+          changes[Constants.STORAGE.HIDE_WHEN_NO_INCIDENTS].newValue;
         setHideWhenNoIncidents(
           typeof nextValue === "boolean" ? nextValue : true,
         );

--- a/src/options/OptionsView.tsx
+++ b/src/options/OptionsView.tsx
@@ -158,8 +158,7 @@ export const OptionsView = (props: OptionsViewProps) => {
               color: PAGE_CSS.muted,
             }}
           >
-            Controls the in-page popup. Turning this off is the same behavior as
-            using "Don&apos;t show me this again".
+            Controls the in-page popup. When disabled, the popup will not appear automatically but can still be opened via the extensions icon.
           </p>
 
           <label

--- a/src/options/OptionsView.tsx
+++ b/src/options/OptionsView.tsx
@@ -20,8 +20,9 @@ const REFRESH_INTERVAL_OPTIONS = [
 
 export type OptionsViewProps = {
   warningsEnabled: boolean;
+  hideWhenNoIncidents: boolean;
   suppressedDomains: string[];
-  suppressedPageNames: string[];
+  snoozedSites: string[];
   refreshIntervalMs: number;
   lastRefreshedAt: number | null;
   refreshingNow: boolean;
@@ -29,10 +30,11 @@ export type OptionsViewProps = {
   lastRefreshError: string | null;
   loading: boolean;
   onToggleWarnings: (enabled: boolean) => void;
+  onToggleHideWhenNoIncidents: (enabled: boolean) => void;
   onChangeRefreshInterval: (refreshIntervalMs: number) => void;
   onRefreshNow: () => void;
   onRemoveSuppressedDomain: (domain: string) => void;
-  onRemoveSuppressedPageName: (pageName: string) => void;
+  onRemoveSnoozedSite: (domain: string) => void;
 };
 
 const formatLastRefreshed = (value: number | null): string => {
@@ -50,8 +52,9 @@ const formatLastRefreshed = (value: number | null): string => {
 export const OptionsView = (props: OptionsViewProps) => {
   const {
     warningsEnabled,
+    hideWhenNoIncidents,
     suppressedDomains,
-    suppressedPageNames,
+    snoozedSites,
     refreshIntervalMs,
     lastRefreshedAt,
     refreshingNow,
@@ -59,10 +62,11 @@ export const OptionsView = (props: OptionsViewProps) => {
     lastRefreshError,
     loading,
     onToggleWarnings,
+    onToggleHideWhenNoIncidents,
     onChangeRefreshInterval,
     onRefreshNow,
     onRemoveSuppressedDomain,
-    onRemoveSuppressedPageName,
+    onRemoveSnoozedSite,
   } = props;
 
   return (
@@ -212,7 +216,7 @@ export const OptionsView = (props: OptionsViewProps) => {
               color: PAGE_CSS.text,
             }}
           >
-            Hidden Products and Companies
+            Automatic Popup Filters
           </h2>
           <p
             style={{
@@ -221,75 +225,44 @@ export const OptionsView = (props: OptionsViewProps) => {
               color: PAGE_CSS.muted,
             }}
           >
-            Remove an item from this list to show matches for it again.
+            Control when automatic in-page popups are shown.
           </p>
 
-          {suppressedPageNames.length === 0 && (
-            <div
-              style={{
-                border: `1px solid ${PAGE_CSS.border}`,
-                borderRadius: "10px",
-                padding: "10px 12px",
-                fontSize: "13px",
-                color: PAGE_CSS.muted,
+          <label
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              border: `1px solid ${PAGE_CSS.border}`,
+              borderRadius: "10px",
+              padding: "10px 12px",
+              fontSize: "14px",
+              color: PAGE_CSS.text,
+            }}
+          >
+            <span>Don&apos;t show matches when there are no incidents</span>
+            <input
+              type="checkbox"
+              checked={hideWhenNoIncidents}
+              disabled={loading}
+              onChange={(event) => {
+                onToggleHideWhenNoIncidents(event.target.checked);
               }}
-            >
-              No hidden products or companies.
-            </div>
-          )}
+              style={{ width: "16px", height: "16px", accentColor: "#FFFFFF" }}
+            />
+          </label>
 
-          {suppressedPageNames.length > 0 && (
-            <div
-              style={{ display: "flex", flexDirection: "column", gap: "8px" }}
-            >
-              {suppressedPageNames.map((pageName) => (
-                <div
-                  key={pageName}
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "space-between",
-                    gap: "8px",
-                    border: `1px solid ${PAGE_CSS.border}`,
-                    borderRadius: "10px",
-                    padding: "8px 10px",
-                    fontSize: "13px",
-                    color: PAGE_CSS.text,
-                  }}
-                >
-                  <span
-                    style={{
-                      minWidth: 0,
-                      overflow: "hidden",
-                      textOverflow: "ellipsis",
-                      whiteSpace: "nowrap",
-                    }}
-                  >
-                    {pageName}
-                  </span>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      onRemoveSuppressedPageName(pageName);
-                    }}
-                    style={{
-                      border: `1px solid ${PAGE_CSS.buttonBorder}`,
-                      background: PAGE_CSS.buttonBg,
-                      color: PAGE_CSS.buttonText,
-                      borderRadius: "8px",
-                      padding: "4px 10px",
-                      fontSize: "12px",
-                      fontWeight: 700,
-                      cursor: "pointer",
-                      flexShrink: 0,
-                    }}
-                  >
-                    Remove
-                  </button>
-                </div>
-              ))}
-            </div>
-          )}
+          <p
+            style={{
+              margin: "8px 0 0 0",
+              fontSize: "12px",
+              color: PAGE_CSS.muted,
+            }}
+          >
+            {hideWhenNoIncidents
+              ? "Enabled: automatic popups are hidden unless incident matches are present."
+              : "Disabled: automatic popups can show even without incident matches."}
+          </p>
         </section>
 
         <section
@@ -368,6 +341,103 @@ export const OptionsView = (props: OptionsViewProps) => {
                     type="button"
                     onClick={() => {
                       onRemoveSuppressedDomain(domain);
+                    }}
+                    style={{
+                      border: `1px solid ${PAGE_CSS.buttonBorder}`,
+                      background: PAGE_CSS.buttonBg,
+                      color: PAGE_CSS.buttonText,
+                      borderRadius: "8px",
+                      padding: "4px 10px",
+                      fontSize: "12px",
+                      fontWeight: 700,
+                      cursor: "pointer",
+                      flexShrink: 0,
+                    }}
+                  >
+                    Remove
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section
+          style={{
+            border: `1px solid ${PAGE_CSS.border}`,
+            borderRadius: "12px",
+            padding: "14px",
+            background: PAGE_CSS.subtleBg,
+          }}
+        >
+          <h2
+            style={{
+              margin: 0,
+              fontSize: "16px",
+              lineHeight: 1.2,
+              fontWeight: 700,
+              color: PAGE_CSS.text,
+            }}
+          >
+            Snoozed Sites
+          </h2>
+          <p
+            style={{
+              margin: "6px 0 10px 0",
+              fontSize: "13px",
+              color: PAGE_CSS.muted,
+            }}
+          >
+            These sites are snoozed until incident matches change.
+          </p>
+
+          {snoozedSites.length === 0 && (
+            <div
+              style={{
+                border: `1px solid ${PAGE_CSS.border}`,
+                borderRadius: "10px",
+                padding: "10px 12px",
+                fontSize: "13px",
+                color: PAGE_CSS.muted,
+              }}
+            >
+              No snoozed sites.
+            </div>
+          )}
+
+          {snoozedSites.length > 0 && (
+            <div
+              style={{ display: "flex", flexDirection: "column", gap: "8px" }}
+            >
+              {snoozedSites.map((domain) => (
+                <div
+                  key={domain}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    gap: "8px",
+                    border: `1px solid ${PAGE_CSS.border}`,
+                    borderRadius: "10px",
+                    padding: "8px 10px",
+                    fontSize: "13px",
+                    color: PAGE_CSS.text,
+                  }}
+                >
+                  <span
+                    style={{
+                      minWidth: 0,
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {domain}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onRemoveSnoozedSite(domain);
                     }}
                     style={{
                       border: `1px solid ${PAGE_CSS.buttonBorder}`,

--- a/src/options/OptionsView.tsx
+++ b/src/options/OptionsView.tsx
@@ -158,7 +158,8 @@ export const OptionsView = (props: OptionsViewProps) => {
               color: PAGE_CSS.muted,
             }}
           >
-            Controls the in-page popup. When disabled, the popup will not appear automatically but can still be opened via the extensions icon.
+            Controls the in-page popup. When disabled, the popup will not appear
+            automatically but can still be opened via the extensions icon.
           </p>
 
           <label

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -26,6 +26,8 @@ export const STORAGE = {
   DATA_REFRESH_INTERVAL_MS: "crw_data_refresh_interval_ms",
   DATA_REFRESH_ERROR: "crw_data_refresh_error",
   SUPPRESSED_DOMAINS: "crw_suppressed_domains",
-  SUPPRESSED_PAGE_NAMES: "crw_suppressed_page_names",
+  SNOOZED_SITES_UNTIL_INCIDENT_CHANGE:
+    "crw_snoozed_sites_until_incident_change",
+  HIDE_WHEN_NO_INCIDENTS: "crw_hide_when_no_incidents",
   WARNINGS_ENABLED: "crw_warnings_enabled",
 };

--- a/src/shared/incidentSignature.ts
+++ b/src/shared/incidentSignature.ts
@@ -1,0 +1,31 @@
+import type { CargoEntry } from "@/shared/types";
+
+const normalizeToken = (value: unknown): string => {
+  if (typeof value !== "string") return "";
+  return value.trim().toLowerCase();
+};
+
+export const getIncidentPrimaryStatusToken = (entry: CargoEntry): string => {
+  if (typeof entry.Status !== "string") return "";
+
+  const [primaryStatus] = entry.Status.split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  return normalizeToken(primaryStatus);
+};
+
+export const buildIncidentSignature = (matches: CargoEntry[]): string => {
+  const tokens = matches
+    .filter((entry) => entry._type === "Incident")
+    .map((entry) => {
+      const incidentId = normalizeToken(entry.PageID);
+      if (!incidentId) return "";
+      const status = getIncidentPrimaryStatusToken(entry);
+      return `${incidentId}|${status}`;
+    })
+    .filter(Boolean)
+    .sort();
+
+  return tokens.join("||");
+};

--- a/src/shared/snoozedSites.ts
+++ b/src/shared/snoozedSites.ts
@@ -12,7 +12,10 @@ export const normalizeSnoozedSiteMap = (
 
   const next: SnoozedSiteMap = {};
   for (const [domain, state] of Object.entries(value)) {
-    const normalizedDomain = domain.trim().toLowerCase().replace(/^www\./, "");
+    const normalizedDomain = domain
+      .trim()
+      .toLowerCase()
+      .replace(/^www\./, "");
     if (!normalizedDomain) continue;
     next[normalizedDomain] = state;
   }

--- a/src/shared/snoozedSites.ts
+++ b/src/shared/snoozedSites.ts
@@ -1,0 +1,21 @@
+export type SnoozedSiteState = {
+  incidentSignature: string;
+  snoozedAt: number;
+};
+
+export type SnoozedSiteMap = Record<string, SnoozedSiteState>;
+
+export const normalizeSnoozedSiteMap = (
+  value: SnoozedSiteMap | null | undefined,
+): SnoozedSiteMap => {
+  if (!value) return {};
+
+  const next: SnoozedSiteMap = {};
+  for (const [domain, state] of Object.entries(value)) {
+    const normalizedDomain = domain.trim().toLowerCase().replace(/^www\./, "");
+    if (!normalizedDomain) continue;
+    next[normalizedDomain] = state;
+  }
+
+  return next;
+};

--- a/src/shared/ui/MatchPopupCard.tsx
+++ b/src/shared/ui/MatchPopupCard.tsx
@@ -23,7 +23,9 @@ type MatchPopupCardProps = {
   hideRelatedButtonWhenEmpty?: boolean;
   containerStyle?: React.CSSProperties;
   suppressButtonLabel?: string;
+  suppressButtonTooltip?: string;
   snoozeUntilNewChangesLabel?: string;
+  snoozeUntilNewChangesTooltip?: string;
   disableWarningsLabel?: string;
   onOpenSettings?: () => void;
   settingsIconUrl?: string;
@@ -189,8 +191,10 @@ export const MatchPopupCard = (props: MatchPopupCardProps) => {
     showCloseButton = false,
     hideRelatedButtonWhenEmpty = false,
     containerStyle,
-    suppressButtonLabel = "Hide for this site",
-    snoozeUntilNewChangesLabel = "Snooze until new changes",
+    suppressButtonLabel = "Always hide for this site",
+    suppressButtonTooltip = "Always hide alerts for this site until you choose to show them again.",
+    snoozeUntilNewChangesLabel = "Hide until new incidents",
+    snoozeUntilNewChangesTooltip = "Hide alerts until there are new incidents.",
     disableWarningsLabel = "Don't show me this again",
     onOpenSettings,
     settingsIconUrl,
@@ -274,8 +278,10 @@ export const MatchPopupCard = (props: MatchPopupCardProps) => {
       <MatchPopupFooterActions
         onSnoozeUntilNewChanges={onSnoozeUntilNewChanges}
         snoozeUntilNewChangesLabel={snoozeUntilNewChangesLabel}
+        snoozeUntilNewChangesTooltip={snoozeUntilNewChangesTooltip}
         onSuppressSite={onSuppressSite}
         suppressButtonLabel={suppressButtonLabel}
+        suppressButtonTooltip={suppressButtonTooltip}
       />
 
       {onDisableWarnings && (

--- a/src/shared/ui/MatchPopupCard.tsx
+++ b/src/shared/ui/MatchPopupCard.tsx
@@ -15,7 +15,7 @@ type MatchPopupCardProps = {
   logoUrl: string;
   externalIconUrl: string;
   onSuppressSite: () => void;
-  onSuppressPageName?: () => void;
+  onSnoozeUntilNewChanges?: () => void;
   onDisableWarnings?: () => void;
   onClose?: () => void;
   domainLabel?: string;
@@ -23,7 +23,7 @@ type MatchPopupCardProps = {
   hideRelatedButtonWhenEmpty?: boolean;
   containerStyle?: React.CSSProperties;
   suppressButtonLabel?: string;
-  suppressPageNameLabel?: string;
+  snoozeUntilNewChangesLabel?: string;
   disableWarningsLabel?: string;
   onOpenSettings?: () => void;
   settingsIconUrl?: string;
@@ -152,11 +152,6 @@ const sortIncidents = (
     .map((row) => row.entry);
 };
 
-const getSuppressScopeLabel = (entry: CargoEntry): string => {
-  if (entry._type === "ProductLine") return "product";
-  return entry._type.toLowerCase();
-};
-
 const getNormalizedPageName = (entry: CargoEntry): string => {
   return normalizeEntityToken(entry.PageName || "");
 };
@@ -187,7 +182,7 @@ export const MatchPopupCard = (props: MatchPopupCardProps) => {
     logoUrl,
     externalIconUrl,
     onSuppressSite,
-    onSuppressPageName,
+    onSnoozeUntilNewChanges,
     onDisableWarnings,
     onClose,
     domainLabel,
@@ -195,7 +190,7 @@ export const MatchPopupCard = (props: MatchPopupCardProps) => {
     hideRelatedButtonWhenEmpty = false,
     containerStyle,
     suppressButtonLabel = "Hide for this site",
-    suppressPageNameLabel,
+    snoozeUntilNewChangesLabel = "Snooze until new changes",
     disableWarningsLabel = "Don't show me this again",
     onOpenSettings,
     settingsIconUrl,
@@ -244,9 +239,6 @@ export const MatchPopupCard = (props: MatchPopupCardProps) => {
   );
   const showsRelatedPagesToggle =
     !hideRelatedButtonWhenEmpty || derived.hiddenRelatedPagesCount > 0;
-  const resolvedSuppressPageNameLabel =
-    suppressPageNameLabel ||
-    `Hide for this ${getSuppressScopeLabel(derived.topMatch)}`;
 
   return (
     <div
@@ -280,8 +272,8 @@ export const MatchPopupCard = (props: MatchPopupCardProps) => {
       />
 
       <MatchPopupFooterActions
-        onSuppressPageName={onSuppressPageName}
-        suppressPageNameLabel={resolvedSuppressPageNameLabel}
+        onSnoozeUntilNewChanges={onSnoozeUntilNewChanges}
+        snoozeUntilNewChangesLabel={snoozeUntilNewChangesLabel}
         onSuppressSite={onSuppressSite}
         suppressButtonLabel={suppressButtonLabel}
       />

--- a/src/shared/ui/MatchPopupFooterActions.tsx
+++ b/src/shared/ui/MatchPopupFooterActions.tsx
@@ -7,8 +7,8 @@ import {
 } from "@/shared/ui/matchPopupStyles";
 
 type MatchPopupFooterActionsProps = {
-  onSuppressPageName?: () => void;
-  suppressPageNameLabel: string;
+  onSnoozeUntilNewChanges?: () => void;
+  snoozeUntilNewChangesLabel: string;
   onSuppressSite: () => void;
   suppressButtonLabel: string;
 };
@@ -17,8 +17,8 @@ export const MatchPopupFooterActions = (
   props: MatchPopupFooterActionsProps,
 ) => {
   const {
-    onSuppressPageName,
-    suppressPageNameLabel,
+    onSnoozeUntilNewChanges,
+    snoozeUntilNewChangesLabel,
     onSuppressSite,
     suppressButtonLabel,
   } = props;
@@ -47,14 +47,14 @@ export const MatchPopupFooterActions = (
 
   return (
     <div style={POPUP_LAYOUT.footerActions}>
-      {onSuppressPageName && (
+      {onSnoozeUntilNewChanges && (
         <button
           type="button"
-          onClick={onSuppressPageName}
+          onClick={onSnoozeUntilNewChanges}
           {...ghostButtonHoverHandlers}
           style={secondaryActionButtonStyle}
         >
-          {suppressPageNameLabel}
+          {snoozeUntilNewChangesLabel}
         </button>
       )}
 

--- a/src/shared/ui/MatchPopupFooterActions.tsx
+++ b/src/shared/ui/MatchPopupFooterActions.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 import {
   POPUP_CSS,
@@ -9,8 +9,10 @@ import {
 type MatchPopupFooterActionsProps = {
   onSnoozeUntilNewChanges?: () => void;
   snoozeUntilNewChangesLabel: string;
+  snoozeUntilNewChangesTooltip?: string;
   onSuppressSite: () => void;
   suppressButtonLabel: string;
+  suppressButtonTooltip: string;
 };
 
 export const MatchPopupFooterActions = (
@@ -19,9 +21,14 @@ export const MatchPopupFooterActions = (
   const {
     onSnoozeUntilNewChanges,
     snoozeUntilNewChangesLabel,
+    snoozeUntilNewChangesTooltip,
     onSuppressSite,
     suppressButtonLabel,
+    suppressButtonTooltip,
   } = props;
+  const [activeTooltip, setActiveTooltip] = useState<
+    "snooze" | "suppress" | null
+  >(null);
 
   const secondaryActionButtonStyle: React.CSSProperties = {
     appearance: "none",
@@ -45,27 +52,103 @@ export const MatchPopupFooterActions = (
     cursor: "pointer",
   };
 
+  const tooltipStyle: React.CSSProperties = {
+    position: "absolute",
+    left: "50%",
+    bottom: "calc(100% + 8px)",
+    transform: "translateX(-50%)",
+    zIndex: 30,
+    width: "max-content",
+    maxWidth: "240px",
+    padding: "8px 10px",
+    borderRadius: "8px",
+    border: "1px solid rgba(216,241,255,0.22)",
+    background:
+      "linear-gradient(180deg, rgba(7,18,41,0.98), rgba(6,15,35,0.94))",
+    boxShadow: "0 10px 24px rgba(0,0,0,0.24)",
+    color: POPUP_CSS.text,
+    fontSize: "11px",
+    lineHeight: 1.35,
+    textAlign: "center",
+    pointerEvents: "none",
+  };
+
+  const tooltipArrowStyle: React.CSSProperties = {
+    position: "absolute",
+    bottom: "-6px",
+    left: "50%",
+    width: "10px",
+    height: "10px",
+    marginLeft: "-5px",
+    background: "rgba(6,15,35,0.96)",
+    borderRight: "1px solid rgba(216,241,255,0.22)",
+    borderBottom: "1px solid rgba(216,241,255,0.22)",
+    transform: "rotate(45deg)",
+  };
+
   return (
     <div style={POPUP_LAYOUT.footerActions}>
       {onSnoozeUntilNewChanges && (
-        <button
-          type="button"
-          onClick={onSnoozeUntilNewChanges}
-          {...ghostButtonHoverHandlers}
-          style={secondaryActionButtonStyle}
-        >
-          {snoozeUntilNewChangesLabel}
-        </button>
+        <div style={{ position: "relative", display: "inline-flex" }}>
+          <button
+            type="button"
+            onClick={onSnoozeUntilNewChanges}
+            onMouseEnter={(event) => {
+              setActiveTooltip("snooze");
+              ghostButtonHoverHandlers.onMouseEnter(event);
+            }}
+            onMouseLeave={(event) => {
+              setActiveTooltip(null);
+              ghostButtonHoverHandlers.onMouseLeave(event);
+            }}
+            onFocus={() => {
+              setActiveTooltip("snooze");
+            }}
+            onBlur={() => {
+              setActiveTooltip(null);
+            }}
+            style={secondaryActionButtonStyle}
+          >
+            {snoozeUntilNewChangesLabel}
+          </button>
+          {activeTooltip === "snooze" && snoozeUntilNewChangesTooltip && (
+            <div role="tooltip" style={tooltipStyle}>
+              <div style={tooltipArrowStyle} aria-hidden="true" />
+              {snoozeUntilNewChangesTooltip}
+            </div>
+          )}
+        </div>
       )}
 
-      <button
-        type="button"
-        onClick={onSuppressSite}
-        {...ghostButtonHoverHandlers}
-        style={secondaryActionButtonStyle}
-      >
-        {suppressButtonLabel}
-      </button>
+      <div style={{ position: "relative", display: "inline-flex" }}>
+        <button
+          type="button"
+          onClick={onSuppressSite}
+          onMouseEnter={(event) => {
+            setActiveTooltip("suppress");
+            ghostButtonHoverHandlers.onMouseEnter(event);
+          }}
+          onMouseLeave={(event) => {
+            setActiveTooltip(null);
+            ghostButtonHoverHandlers.onMouseLeave(event);
+          }}
+          onFocus={() => {
+            setActiveTooltip("suppress");
+          }}
+          onBlur={() => {
+            setActiveTooltip(null);
+          }}
+          style={secondaryActionButtonStyle}
+        >
+          {suppressButtonLabel}
+        </button>
+        {activeTooltip === "suppress" && (
+          <div role="tooltip" style={tooltipStyle}>
+            <div style={tooltipArrowStyle} aria-hidden="true" />
+            {suppressButtonTooltip}
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/tests/incidentSignature.test.ts
+++ b/tests/incidentSignature.test.ts
@@ -1,0 +1,71 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildIncidentSignature,
+  getIncidentPrimaryStatusToken,
+} from "../src/shared/incidentSignature.ts";
+import { entry } from "./helpers.ts";
+
+test("getIncidentPrimaryStatusToken returns first status token", () => {
+  const token = getIncidentPrimaryStatusToken(
+    entry({
+      _type: "Incident",
+      PageID: "incident-a",
+      PageName: "Incident A",
+      Status: "Active, Monitoring",
+    }),
+  );
+
+  assert.equal(token, "active");
+});
+
+test("buildIncidentSignature is order-insensitive and status-sensitive", () => {
+  const aThenB = buildIncidentSignature([
+    entry({
+      _type: "Incident",
+      PageID: "incident-a",
+      PageName: "Incident A",
+      Status: "Active",
+    }),
+    entry({
+      _type: "Incident",
+      PageID: "incident-b",
+      PageName: "Incident B",
+      Status: "Resolved",
+    }),
+  ]);
+
+  const bThenA = buildIncidentSignature([
+    entry({
+      _type: "Incident",
+      PageID: "incident-b",
+      PageName: "Incident B",
+      Status: "Resolved",
+    }),
+    entry({
+      _type: "Incident",
+      PageID: "incident-a",
+      PageName: "Incident A",
+      Status: "Active",
+    }),
+  ]);
+
+  const statusChanged = buildIncidentSignature([
+    entry({
+      _type: "Incident",
+      PageID: "incident-a",
+      PageName: "Incident A",
+      Status: "Monitoring",
+    }),
+    entry({
+      _type: "Incident",
+      PageID: "incident-b",
+      PageName: "Incident B",
+      Status: "Resolved",
+    }),
+  ]);
+
+  assert.equal(aThenB, bThenA);
+  assert.notEqual(aThenB, statusChanged);
+});

--- a/tests/matchPopupCard.component.test.ts
+++ b/tests/matchPopupCard.component.test.ts
@@ -73,7 +73,7 @@ test("MatchPopupCard incident list shows first status token and sorts active inc
   assert.equal(html.includes("Investigating"), false);
 });
 
-test("MatchPopupCard renders page suppression action when handler is provided", () => {
+test("MatchPopupCard renders snooze action when handler is provided", () => {
   const html = renderToStaticMarkup(
     React.createElement(MatchPopupCard, {
       matches: [
@@ -86,11 +86,11 @@ test("MatchPopupCard renders page suppression action when handler is provided", 
       logoUrl: "/logo.png",
       externalIconUrl: "/open-in-new.svg",
       onSuppressSite: noop,
-      onSuppressPageName: noop,
+      onSnoozeUntilNewChanges: noop,
     }),
   );
 
-  assert.ok(html.includes("Hide for this product"));
+  assert.ok(html.includes("Snooze until new changes"));
 });
 
 test("MatchPopupCard prefers product-linked company over marketplace company", () => {

--- a/tests/matchPopupCard.component.test.ts
+++ b/tests/matchPopupCard.component.test.ts
@@ -90,7 +90,7 @@ test("MatchPopupCard renders snooze action when handler is provided", () => {
     }),
   );
 
-  assert.ok(html.includes("Snooze until new changes"));
+  assert.ok(html.includes("Hide until new incidents"));
 });
 
 test("MatchPopupCard prefers product-linked company over marketplace company", () => {

--- a/tests/optionsView.component.test.ts
+++ b/tests/optionsView.component.test.ts
@@ -11,8 +11,9 @@ test("OptionsView shows enabled state and empty ignored-sites list", () => {
   const html = renderToStaticMarkup(
     React.createElement(OptionsView, {
       warningsEnabled: true,
+      hideWhenNoIncidents: true,
       suppressedDomains: [],
-      suppressedPageNames: [],
+      snoozedSites: [],
       refreshIntervalMs: 24 * 60 * 60 * 1000,
       lastRefreshedAt: null,
       refreshingNow: false,
@@ -20,10 +21,11 @@ test("OptionsView shows enabled state and empty ignored-sites list", () => {
       lastRefreshError: null,
       loading: false,
       onToggleWarnings: noop,
+      onToggleHideWhenNoIncidents: noop,
       onChangeRefreshInterval: noop,
       onRefreshNow: noop,
       onRemoveSuppressedDomain: noop,
-      onRemoveSuppressedPageName: noop,
+      onRemoveSnoozedSite: noop,
     }),
   );
 
@@ -37,15 +39,21 @@ test("OptionsView shows enabled state and empty ignored-sites list", () => {
   assert.ok(html.includes("Last refreshed: Never"));
   assert.ok(html.includes("Refresh now"));
   assert.ok(html.includes("No ignored sites."));
-  assert.ok(html.includes("No hidden products or companies."));
+  assert.ok(html.includes("No snoozed sites."));
+  assert.ok(
+    html.includes(
+      "Enabled: automatic popups are hidden unless incident matches are present.",
+    ),
+  );
 });
 
 test("OptionsView shows disabled state and removable ignored-site entries", () => {
   const html = renderToStaticMarkup(
     React.createElement(OptionsView, {
       warningsEnabled: false,
+      hideWhenNoIncidents: false,
       suppressedDomains: ["example.com"],
-      suppressedPageNames: ["airpods"],
+      snoozedSites: ["shop.example"],
       refreshIntervalMs: 60 * 60 * 1000,
       lastRefreshedAt: Date.UTC(2026, 1, 22, 18, 30),
       refreshingNow: true,
@@ -53,16 +61,22 @@ test("OptionsView shows disabled state and removable ignored-site entries", () =
       lastRefreshError: "Failed to fetch dataset (500)",
       loading: true,
       onToggleWarnings: noop,
+      onToggleHideWhenNoIncidents: noop,
       onChangeRefreshInterval: noop,
       onRefreshNow: noop,
       onRemoveSuppressedDomain: noop,
-      onRemoveSuppressedPageName: noop,
+      onRemoveSnoozedSite: noop,
     }),
   );
 
   assert.ok(html.includes("Disabled: popups will not auto-show on page load."));
   assert.ok(html.includes("example.com"));
-  assert.ok(html.includes("airpods"));
+  assert.ok(html.includes("shop.example"));
+  assert.ok(
+    html.includes(
+      "Disabled: automatic popups can show even without incident matches.",
+    ),
+  );
   assert.ok(html.includes("Remove"));
   assert.ok(html.includes("Refreshing..."));
   assert.ok(html.includes("Refresh failed. Please try again."));


### PR DESCRIPTION
User-visible behavior is changing in three ways:

- The in-page popup action **“Hide this Company”** is being replaced with **“Snooze until new incidents.”**
- When a user clicks **“Snooze until new incidents,”** the popup stays hidden for that site until the site’s incident list changes (new/removed incident or status change), then it will automatically show again.
- A new Options setting (enabled by default) will **not auto-show matches when there are no incidents**. This only affects automatic popup display; users can still manually open the popup.

Also in Options:

- The old **Hidden Products and Companies** list is removed.
- A new **Snoozed Sites** list is added so users can manually unsnooze a site before incident changes occur.


<img width="590" height="482" alt="image" src="https://github.com/user-attachments/assets/80a57d6b-2b75-41a3-9d8e-443e4727415a" />

<img width="791" height="906" alt="image" src="https://github.com/user-attachments/assets/77b59744-8eb6-4e01-a07e-b18fc4d28161" />

Closes:
- https://github.com/FULU-Foundation/CRW-Extension/issues/121
- https://github.com/FULU-Foundation/CRW-Extension/issues/112 
- https://github.com/FULU-Foundation/CRW-Extension/issues/57