### PR TITLE
Add compact badge mode and toolbar popup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@ node_modules
 .idea/
 *.iml
 src/generated/
+
+# Nix
+result
+result-*
+.shell.nix
+flake.nix

--- a/manifest/chrome.json
+++ b/manifest/chrome.json
@@ -6,6 +6,7 @@
   "description": "Shows a popup and notifications when the current site may have an article on the Consumer Rights Wiki.",
   "action": {
     "default_title": "CRW Extension",
+    "default_popup": "popup.html",
     "default_icon": {
       "16": "crw_logo.png",
       "32": "crw_logo.png",

--- a/manifest/firefox.json
+++ b/manifest/firefox.json
@@ -7,6 +7,7 @@
   "homepage_url": "https://github.com/FULU-Foundation/CRW-Extension",
   "action": {
     "default_title": "CRW Extension",
+    "default_popup": "popup.html",
     "default_icon": {
       "16": "crw_logo.png",
       "32": "crw_logo.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1435,6 +1436,7 @@
       "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1445,6 +1447,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1518,6 +1521,7 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -1776,6 +1780,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1951,6 +1956,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2363,6 +2369,7 @@
       "integrity": "sha512-20MV9SUdeN6Jd84xESsKhRly+/vxI+hwvpBMA93s+9dAcjdCuCojn4IqUGS3lvVaqjVYGYHSRMCpeFtF2rQYxQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3398,6 +3405,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3654,6 +3662,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3727,6 +3736,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -3767,6 +3777,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3874,6 +3885,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3990,6 +4002,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -6,16 +6,98 @@ import * as Dataset from "@/lib/dataset";
 import * as Messaging from "@/messaging";
 import { MessageType } from "@/messaging/type";
 import { CargoEntry } from "@/shared/types";
-import { readDatasetCacheRefreshInfo, readTabMatches } from "@/shared/storage";
+import {
+  readDatasetCacheRefreshInfo,
+  readDisplayMode,
+  readTabMatches,
+} from "@/shared/storage";
+import type { DisplayMode } from "@/shared/constants";
 
 let datasetCache: CargoEntry[] = [];
 let datasetLoadPromise: Promise<CargoEntry[]> | null = null;
 let nextDatasetRefreshCheckAt = 0;
+let currentDisplayMode: DisplayMode = "full-popup";
 
-const getBadgeText = (count: number): string => {
-  if (count <= 0) return "";
-  if (count > 3) return "3+";
-  return String(count);
+const getBadgeColor = (count: number): string => {
+  if (count <= 0) return "#9E9E9E";
+  if (count <= 1) return "#4CAF50";
+  if (count <= 3) return "#FF9800";
+  return "#FF5722";
+};
+
+const getBadgeTextColor = (): string => {
+  return "#FFFFFF";
+};
+
+const getIncidentCount = (matches: CargoEntry[]): number => {
+  return matches.filter((m) => m._type === "Incident").length;
+};
+
+const getSiteName = (hostname: string): string => {
+  const parts = hostname.replace(/^www\./, "").split(".");
+  if (parts.length >= 2) {
+    return parts[0];
+  }
+  return hostname;
+};
+
+const updateBadge = async (
+  tabId: number,
+  matches: CargoEntry[],
+  hostname: string,
+): Promise<void> => {
+  const displayMode = await readDisplayMode();
+  currentDisplayMode = displayMode;
+
+  const incidentCount = getIncidentCount(matches);
+  const siteName = getSiteName(hostname);
+
+  if (displayMode === "badge-only" || displayMode === "compact-badge") {
+    const badgeText =
+      incidentCount <= 0
+        ? ""
+        : incidentCount > 3
+          ? "3+"
+          : String(incidentCount);
+
+    browser.action.setBadgeText({
+      tabId,
+      text: badgeText,
+    });
+    browser.action.setBadgeBackgroundColor({
+      tabId,
+      color: getBadgeColor(incidentCount),
+    });
+    browser.action.setBadgeTextColor({
+      tabId,
+      color: getBadgeTextColor(),
+    });
+
+    if (displayMode === "compact-badge") {
+      const tooltipText =
+        incidentCount <= 0
+          ? `${siteName}: No incidents`
+          : `${siteName}: ${incidentCount} incident${incidentCount === 1 ? "" : "s"}`;
+      browser.action.setTitle({
+        tabId,
+        title: tooltipText,
+      });
+    } else {
+      browser.action.setTitle({
+        tabId,
+        title: `Consumer Rights Wiki\n${siteName}: ${incidentCount} incident${incidentCount === 1 ? "" : "s"}`,
+      });
+    }
+  } else {
+    browser.action.setBadgeText({
+      tabId,
+      text: "",
+    });
+    browser.action.setTitle({
+      tabId,
+      title: `Consumer Rights Wiki\n${siteName}: ${incidentCount} incident${incidentCount === 1 ? "" : "s"}`,
+    });
+  }
 };
 
 const sendMatchUpdateToTab = async (
@@ -27,6 +109,10 @@ const sendMatchUpdateToTab = async (
     | MessageType.TOGGLE_INLINE_POPUP = MessageType.MATCH_RESULTS_UPDATED,
   attempt = 0,
 ): Promise<void> => {
+  if (currentDisplayMode === "badge-only") {
+    return;
+  }
+
   try {
     await browser.tabs.sendMessage(
       tabId,
@@ -104,20 +190,21 @@ browser.storage.onChanged.addListener((changes, areaName) => {
   if (changes[Constants.STORAGE.DATA_REFRESH_INTERVAL_MS]) {
     nextDatasetRefreshCheckAt = 0;
   }
+
+  if (changes[Constants.STORAGE.DISPLAY_MODE]) {
+    currentDisplayMode = changes[Constants.STORAGE.DISPLAY_MODE]
+      .newValue as DisplayMode;
+  }
 });
 
-browser.tabs.onActivated.addListener(async ({ tabId }) => {
+browser.tabs.onActivated.addListener(async ({ tabId, tab }) => {
   console.log(
     `${Constants.LOG_PREFIX} Active tab has been changed. TabId:${tabId}`,
   );
 
   const results = await readTabMatches(tabId);
-
-  browser.action.setBadgeText({
-    tabId,
-    text: getBadgeText(results.length),
-  });
-  browser.action.setBadgeBackgroundColor({ tabId, color: "#FF5722" });
+  const hostname = tab?.url ? new URL(tab.url).hostname : "";
+  await updateBadge(tabId, results, hostname);
 });
 
 browser.action.onClicked.addListener(async (tab) => {
@@ -140,6 +227,7 @@ Messaging.createBackgroundMessageHandler({
   async onPageContextUpdated(payload, sender) {
     const tabId = sender.tab?.id;
     if (!tabId) return;
+    const hostname = sender.tab?.url ? new URL(sender.tab.url).hostname : "";
     const dataset = await loadDatasetCache();
     const storageKey = Constants.STORAGE.MATCHES(tabId);
 
@@ -149,12 +237,7 @@ Messaging.createBackgroundMessageHandler({
       [storageKey]: matches,
     });
 
-    browser.action.setBadgeText({
-      tabId,
-      text: getBadgeText(matches.length),
-    });
-    browser.action.setBadgeBackgroundColor({ tabId, color: "#FF5722" });
-
+    await updateBadge(tabId, matches, hostname);
     void sendMatchUpdateToTab(tabId, matches);
   },
 });

--- a/src/content/CompactBanner.tsx
+++ b/src/content/CompactBanner.tsx
@@ -1,0 +1,255 @@
+import React, { useState } from "react";
+import browser from "webextension-polyfill";
+
+import { CargoEntry, isIncidentEntry } from "@/shared/types";
+
+type CompactBannerProps = {
+  matches: CargoEntry[];
+  logoUrl: string;
+  onClose: () => void;
+  onOpenSettings: () => void;
+};
+
+const getIncidentCount = (matches: CargoEntry[]): number => {
+  return matches.filter((m) => isIncidentEntry(m)).length;
+};
+
+const getTotalCount = (matches: CargoEntry[]): number => {
+  return matches.length;
+};
+
+const getBannerColor = (count: number): string => {
+  if (count <= 0) return "#9E9E9E";
+  if (count <= 1) return "#4CAF50";
+  if (count <= 3) return "#FF9800";
+  return "#FF5722";
+};
+
+const getSiteName = (hostname: string): string => {
+  const parts = hostname.replace(/^www\./, "").split(".");
+  if (parts.length >= 2) {
+    return parts[0];
+  }
+  return hostname;
+};
+
+export const CompactBanner = (props: CompactBannerProps) => {
+  const { matches, logoUrl, onClose, onOpenSettings } = props;
+  const [showPopup, setShowPopup] = useState(false);
+  const [hoverTimeout, setHoverTimeout] = useState<ReturnType<
+    typeof setTimeout
+  > | null>(null);
+
+  const handleMouseLeave = () => {
+    const timeout = setTimeout(() => {
+      setShowPopup(false);
+    }, 300);
+    setHoverTimeout(timeout);
+  };
+
+  const handleMouseEnter = () => {
+    if (hoverTimeout) {
+      clearTimeout(hoverTimeout);
+      setHoverTimeout(null);
+    }
+    setShowPopup(true);
+  };
+
+  const incidentCount = getIncidentCount(matches);
+  const totalCount = getTotalCount(matches);
+  const hostname = matches[0]?.PageName || "this site";
+  const siteName = getSiteName(hostname);
+  const bannerColor = getBannerColor(incidentCount);
+  const bannerOpacity = incidentCount > 0 ? 0.85 : 0.6;
+  const incidents = matches.filter((m) => isIncidentEntry(m));
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        top: "56px",
+        right: "16px",
+        width: "auto",
+        maxWidth: "300px",
+        height: "36px",
+        backgroundColor: bannerColor,
+        opacity: bannerOpacity,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        padding: "0 10px",
+        fontFamily: "ui-sans-serif, system-ui, sans-serif",
+        fontSize: "12px",
+        color: "#FFFFFF",
+        zIndex: 2147483647,
+        borderRadius: "8px",
+        boxShadow: "0 2px 12px rgba(0,0,0,0.25)",
+      }}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+        <img
+          src={logoUrl}
+          alt=""
+          style={{ width: "18px", height: "18px", borderRadius: "4px" }}
+        />
+        <span style={{ fontWeight: 600 }}>{siteName}</span>
+        <span
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "4px",
+            marginLeft: "4px",
+          }}
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="#FFEB3B">
+            <path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z" />
+          </svg>
+          {incidentCount}
+        </span>
+        <span style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="#FFFFFF"
+            opacity="0.9"
+          >
+            <path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z" />
+          </svg>
+          {totalCount}
+        </span>
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+        <button
+          onClick={onOpenSettings}
+          style={{
+            background: "transparent",
+            border: "none",
+            color: "#FFFFFF",
+            cursor: "pointer",
+            padding: "4px",
+            display: "flex",
+            alignItems: "center",
+            opacity: 0.8,
+          }}
+          title="Settings"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M19.14 12.94c.04-.31.06-.63.06-.94 0-.31-.02-.63-.06-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z" />
+          </svg>
+        </button>
+        <button
+          onClick={onClose}
+          style={{
+            background: "transparent",
+            border: "none",
+            color: "#FFFFFF",
+            cursor: "pointer",
+            padding: "4px",
+            display: "flex",
+            alignItems: "center",
+            opacity: 0.8,
+          }}
+          title="Close"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+          </svg>
+        </button>
+      </div>
+
+      {showPopup && incidents.length > 0 && (
+        <div
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+          style={{
+            position: "absolute",
+            top: "100%",
+            right: "0",
+            marginTop: "8px",
+            width: "260px",
+            maxHeight: "200px",
+            overflowY: "auto",
+            backgroundColor: "rgba(255, 255, 255, 0.88)",
+            backdropFilter: "blur(8px)",
+            borderRadius: "8px",
+            boxShadow: "0 4px 20px rgba(0,0,0,0.25)",
+            zIndex: 2147483647,
+            padding: "6px 0",
+          }}
+        >
+          <div
+            style={{
+              padding: "6px 12px",
+              fontSize: "10px",
+              fontWeight: 700,
+              color: "#888",
+              textTransform: "uppercase",
+              borderBottom: "1px solid rgba(0,0,0,0.08)",
+              marginBottom: "4px",
+              display: "flex",
+              alignItems: "center",
+              gap: "8px",
+            }}
+          >
+            <span style={{ display: "flex", alignItems: "center", gap: "3px" }}>
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="#FF9800">
+                <path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z" />
+              </svg>
+              {incidentCount} Incident{incidentCount !== 1 ? "s" : ""}
+            </span>
+            <span style={{ display: "flex", alignItems: "center", gap: "3px" }}>
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="#666">
+                <path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z" />
+              </svg>
+              {totalCount} Article{totalCount !== 1 ? "s" : ""}
+            </span>
+          </div>
+          {incidents.map((match) => {
+            const url = `https://consumerrights.wiki/${encodeURIComponent(match.PageName)}`;
+            return (
+              <div
+                key={match.PageID}
+                role="button"
+                tabIndex={0}
+                onClick={() => window.open(url, "_blank")}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    window.open(url, "_blank");
+                  }
+                }}
+                style={{
+                  display: "block",
+                  width: "100%",
+                  textDecoration: "none",
+                  padding: "6px 12px",
+                  cursor: "pointer",
+                  background: "transparent",
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.backgroundColor = "rgba(0,0,0,0.04)";
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.backgroundColor = "transparent";
+                }}
+              >
+                <div
+                  style={{
+                    fontSize: "12px",
+                    color: "#222",
+                    fontWeight: 500,
+                    lineHeight: 1.3,
+                  }}
+                >
+                  {match.PageName}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -10,6 +10,7 @@ import {
   readSnoozedSiteMap,
   readSuppressedDomains,
   readWarningsEnabled,
+  readDisplayMode,
   writeSnoozedSiteMap,
   writeSuppressedDomains,
   writeWarningsEnabled,
@@ -17,6 +18,7 @@ import {
 import * as Messaging from "@/messaging";
 import { MessageType } from "@/messaging/type";
 import { InlinePopup } from "@/content/InlinePopup";
+import { CompactBanner } from "@/content/CompactBanner";
 import { InlineEmptyState } from "@/content/InlineEmptyState";
 import {
   getInlinePopupInstruction,
@@ -226,6 +228,7 @@ const renderInlinePopup = async (
   ignorePreferences = false,
 ) => {
   const visibleMatches = matches;
+  const displayMode = await readDisplayMode();
 
   const currentlyWarningsEnabled = await isWarningsEnabled();
 
@@ -266,6 +269,23 @@ const renderInlinePopup = async (
 
   forcePopupVisible = ignorePreferences;
   const root = ensurePopupRoot();
+
+  if (displayMode === "compact-badge") {
+    if (visibleMatches.length === 0) {
+      removeInlinePopup();
+      return;
+    }
+    root.render(
+      <CompactBanner
+        matches={visibleMatches}
+        logoUrl={ASSET_URLS.logo}
+        onClose={removeInlinePopup}
+        onOpenSettings={openOptions}
+      />,
+    );
+    return;
+  }
+
   if (visibleMatches.length === 0) {
     root.render(
       <InlineEmptyState

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -13,11 +13,15 @@ import {
   readSnoozedSiteMap,
   readSuppressedDomains,
   readWarningsEnabled,
+  readDisplayMode,
   writeHideWhenNoIncidents,
   writeSnoozedSiteMap,
   writeSuppressedDomains,
   writeWarningsEnabled,
+  writeDisplayMode,
 } from "@/shared/storage";
+
+import type { DisplayMode } from "@/shared/constants";
 
 const normalizeHostname = (hostname: string): string => {
   return hostname
@@ -45,6 +49,7 @@ const decodeRefreshNowResponseFetchedAt = (value: unknown): number | null => {
 const Options = () => {
   const [warningsEnabled, setWarningsEnabled] = useState<boolean>(true);
   const [hideWhenNoIncidents, setHideWhenNoIncidents] = useState<boolean>(true);
+  const [displayMode, setDisplayMode] = useState<DisplayMode>("full-popup");
   const [suppressedDomains, setSuppressedDomains] = useState<string[]>([]);
   const [snoozedSites, setSnoozedSites] = useState<string[]>([]);
   const [refreshIntervalMs, setRefreshIntervalMs] = useState<number>(
@@ -62,6 +67,7 @@ const Options = () => {
         const [
           enabled,
           hideWithoutIncidents,
+          mode,
           domains,
           snoozedSiteDomains,
           intervalMs,
@@ -70,6 +76,7 @@ const Options = () => {
         ] = await Promise.all([
           readWarningsEnabled(),
           readHideWhenNoIncidents(),
+          readDisplayMode(),
           readSuppressedDomains(),
           readSnoozedSites(),
           readRefreshIntervalMs(),
@@ -78,6 +85,7 @@ const Options = () => {
         ]);
         setWarningsEnabled(enabled);
         setHideWhenNoIncidents(hideWithoutIncidents);
+        setDisplayMode(mode);
         setSuppressedDomains(
           domains
             .map((domain) => normalizeHostname(domain))
@@ -120,6 +128,10 @@ const Options = () => {
         void readHideWhenNoIncidents().then(setHideWhenNoIncidents);
       }
 
+      if (changes[Constants.STORAGE.DISPLAY_MODE]) {
+        void readDisplayMode().then(setDisplayMode);
+      }
+
       if (changes[Constants.STORAGE.SUPPRESSED_DOMAINS]) {
         void readSuppressedDomains().then((domains) => {
           setSuppressedDomains(
@@ -156,6 +168,11 @@ const Options = () => {
   const onToggleHideWhenNoIncidents = async (enabled: boolean) => {
     setHideWhenNoIncidents(enabled);
     await writeHideWhenNoIncidents(enabled);
+  };
+
+  const onChangeDisplayMode = async (mode: DisplayMode) => {
+    setDisplayMode(mode);
+    await writeDisplayMode(mode);
   };
 
   const onRemoveSnoozedSite = async (domain: string) => {
@@ -213,6 +230,7 @@ const Options = () => {
     <OptionsView
       warningsEnabled={warningsEnabled}
       hideWhenNoIncidents={hideWhenNoIncidents}
+      displayMode={displayMode}
       suppressedDomains={suppressedDomains}
       snoozedSites={snoozedSites}
       refreshIntervalMs={refreshIntervalMs}
@@ -226,6 +244,9 @@ const Options = () => {
       }}
       onToggleHideWhenNoIncidents={(enabled) => {
         void onToggleHideWhenNoIncidents(enabled);
+      }}
+      onChangeDisplayMode={(mode) => {
+        void onChangeDisplayMode(mode);
       }}
       onChangeRefreshInterval={(nextRefreshIntervalMs) => {
         void onChangeRefreshInterval(nextRefreshIntervalMs);

--- a/src/options/OptionsView.tsx
+++ b/src/options/OptionsView.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 
+import type { DisplayMode } from "@/shared/constants";
+
 const PAGE_CSS = {
   bg: "#004080",
   border: "rgba(255,255,255,0.25)",
@@ -18,9 +20,16 @@ const REFRESH_INTERVAL_OPTIONS = [
   { value: 7 * 24 * 60 * 60 * 1000, label: "1 week" },
 ] as const;
 
+const DISPLAY_MODE_LABELS: Record<DisplayMode, string> = {
+  "full-popup": "Full popup",
+  "badge-only": "Badge only",
+  "compact-badge": "Compact badge",
+};
+
 export type OptionsViewProps = {
   warningsEnabled: boolean;
   hideWhenNoIncidents: boolean;
+  displayMode: DisplayMode;
   suppressedDomains: string[];
   snoozedSites: string[];
   refreshIntervalMs: number;
@@ -31,6 +40,7 @@ export type OptionsViewProps = {
   loading: boolean;
   onToggleWarnings: (enabled: boolean) => void;
   onToggleHideWhenNoIncidents: (enabled: boolean) => void;
+  onChangeDisplayMode: (mode: DisplayMode) => void;
   onChangeRefreshInterval: (refreshIntervalMs: number) => void;
   onRefreshNow: () => void;
   onRemoveSuppressedDomain: (domain: string) => void;
@@ -53,6 +63,7 @@ export const OptionsView = (props: OptionsViewProps) => {
   const {
     warningsEnabled,
     hideWhenNoIncidents,
+    displayMode,
     suppressedDomains,
     snoozedSites,
     refreshIntervalMs,
@@ -63,6 +74,7 @@ export const OptionsView = (props: OptionsViewProps) => {
     loading,
     onToggleWarnings,
     onToggleHideWhenNoIncidents,
+    onChangeDisplayMode,
     onChangeRefreshInterval,
     onRefreshNow,
     onRemoveSuppressedDomain,
@@ -196,6 +208,93 @@ export const OptionsView = (props: OptionsViewProps) => {
             {warningsEnabled
               ? "Enabled: matching popups can show automatically."
               : "Disabled: popups will not auto-show on page load."}
+          </p>
+        </section>
+
+        <section
+          style={{
+            border: `1px solid ${PAGE_CSS.border}`,
+            borderRadius: "12px",
+            padding: "14px",
+            background: PAGE_CSS.subtleBg,
+          }}
+        >
+          <h2
+            style={{
+              margin: 0,
+              fontSize: "16px",
+              lineHeight: 1.2,
+              fontWeight: 700,
+              color: PAGE_CSS.text,
+            }}
+          >
+            Display Mode
+          </h2>
+          <p
+            style={{
+              margin: "6px 0 10px 0",
+              fontSize: "13px",
+              color: PAGE_CSS.muted,
+            }}
+          >
+            Choose how matches are displayed in the browser toolbar.
+          </p>
+
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "10px",
+              border: `1px solid ${PAGE_CSS.border}`,
+              borderRadius: "10px",
+              padding: "10px 12px",
+              fontSize: "13px",
+              color: PAGE_CSS.text,
+            }}
+          >
+            {(
+              ["full-popup", "badge-only", "compact-badge"] as DisplayMode[]
+            ).map((mode) => (
+              <label
+                key={mode}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "10px",
+                  cursor: "pointer",
+                }}
+              >
+                <input
+                  type="radio"
+                  name="displayMode"
+                  checked={displayMode === mode}
+                  disabled={loading}
+                  onChange={() => {
+                    onChangeDisplayMode(mode);
+                  }}
+                  style={{
+                    width: "16px",
+                    height: "16px",
+                    accentColor: "#FFFFFF",
+                  }}
+                />
+                <span>{DISPLAY_MODE_LABELS[mode]}</span>
+              </label>
+            ))}
+          </div>
+
+          <p
+            style={{
+              margin: "8px 0 0 0",
+              fontSize: "12px",
+              color: PAGE_CSS.muted,
+            }}
+          >
+            {displayMode === "full-popup"
+              ? "Full popup: Shows full popup on page with site info and incidents."
+              : displayMode === "badge-only"
+                ? "Badge only: Shows number badge on extension icon."
+                : "Compact badge: Shows small badge with site name and count."}
           </p>
         </section>
 

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -6,6 +6,7 @@ import {
   readSuppressedDomains,
   readTabMatches,
   writeSuppressedDomains,
+  readDisplayMode,
 } from "@/shared/storage";
 
 const POPUP_BG = "#004080";
@@ -65,6 +66,12 @@ const Popup = () => {
 
         const results = await readTabMatches(tabId);
         setArticles(results);
+
+        const displayMode = await readDisplayMode();
+        if (displayMode === "compact-badge" && results.length > 0) {
+          window.close();
+          return;
+        }
       } catch {
         setDomain("unknown");
         setSuppressed(false);

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -18,6 +18,14 @@ export const DATASET_KEYS: CargoEntryType[] = [
   "ProductLine",
 ];
 
+export type DisplayMode = "full-popup" | "badge-only" | "compact-badge";
+
+export const DISPLAY_MODE_OPTIONS: DisplayMode[] = [
+  "full-popup",
+  "badge-only",
+  "compact-badge",
+];
+
 export const STORAGE = {
   MATCHES: (tabId: number) => {
     return `crw_matched_${tabId}`;
@@ -30,4 +38,5 @@ export const STORAGE = {
     "crw_snoozed_sites_until_incident_change",
   HIDE_WHEN_NO_INCIDENTS: "crw_hide_when_no_incidents",
   WARNINGS_ENABLED: "crw_warnings_enabled",
+  DISPLAY_MODE: "crw_display_mode",
 } as const;

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -2,6 +2,7 @@ import browser from "webextension-polyfill";
 
 import * as Constants from "@/shared/constants";
 import { type CargoEntry, decodeCargoEntries } from "@/shared/types";
+import type { DisplayMode } from "@/shared/constants";
 import {
   type SnoozedSiteMap,
   normalizeSnoozedSiteMap,
@@ -137,4 +138,20 @@ export const readTabMatches = async (tabId: number): Promise<CargoEntry[]> => {
   const key = Constants.STORAGE.MATCHES(tabId);
   const value = await readLocalValue(key);
   return decodeCargoEntries(value);
+};
+
+const isDisplayMode = (value: unknown): value is DisplayMode => {
+  return (
+    typeof value === "string" &&
+    Constants.DISPLAY_MODE_OPTIONS.includes(value as DisplayMode)
+  );
+};
+
+export const readDisplayMode = async (): Promise<DisplayMode> => {
+  const value = await readLocalValue(Constants.STORAGE.DISPLAY_MODE);
+  return isDisplayMode(value) ? value : "full-popup";
+};
+
+export const writeDisplayMode = async (mode: DisplayMode): Promise<void> => {
+  await writeLocalValue(Constants.STORAGE.DISPLAY_MODE, mode);
 };


### PR DESCRIPTION
It's better for use IMO : 

- Add compact-badge display mode with floating indicator
- Add popup menu accessible from extension toolbar icon
- Add settings page with snooze and suppression options
- Update manifest files with popup configuration
- Fix popup closing when compact mode is active with matches


The mode can now be chosen on the options : 

<img width="715" height="224" alt="image" src="https://github.com/user-attachments/assets/35ba5035-c376-4762-9080-9fbf016e5b75" />

The compact mode : 

<img width="885" height="190" alt="image" src="https://github.com/user-attachments/assets/467062be-64a3-4599-8454-dfbccd46192d" />

And when you hover over it : 

<img width="912" height="411" alt="image" src="https://github.com/user-attachments/assets/9adf5d8d-3c2c-4a6c-a66b-2fa0cec1d53b" />


Then the badge only is just the idea of popping the amount of incidents / articles (still not clear to me ) without a window pop up : 

<img width="41" height="44" alt="image" src="https://github.com/user-attachments/assets/8e001d67-ed00-4035-86e8-fb4bab1b4032" />

If you click on it, you get the same banner as the wide mode, which is the default others created. 
