### PR TITLE
Fix snooze button instantly reappearing on same-hostname pages

### DIFF
--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -80,19 +80,40 @@ const snoozeCurrentSiteUntilNewIncidentChanges = async (
     );
   }
   const snoozedSiteMap = await readSnoozedSiteMap();
-  snoozedSiteMap[current] = {
-    incidentSignature,
-    snoozedAt: Date.now(),
-  };
+  const entries = snoozedSiteMap[current] || [];
+  const existingIndex = entries.findIndex(
+    (entry) => entry.incidentSignature === incidentSignature,
+  );
+  if (existingIndex >= 0) {
+    entries[existingIndex] = { incidentSignature, snoozedAt: Date.now() };
+  } else {
+    entries.push({ incidentSignature, snoozedAt: Date.now() });
+  }
+  snoozedSiteMap[current] = entries;
   await writeSnoozedSiteMap(snoozedSiteMap);
 };
 
-const unsnoozeCurrentSiteUntilNewIncidentChanges = async (): Promise<void> => {
+const unsnoozeCurrentSiteUntilNewIncidentChanges = async (
+  incidentSignature?: string,
+): Promise<void> => {
   const current = normalizeHostname(location.hostname || "");
   if (!current) return;
   const snoozedSiteMap = await readSnoozedSiteMap();
-  if (!snoozedSiteMap[current]) return;
-  delete snoozedSiteMap[current];
+  const entries = snoozedSiteMap[current];
+  if (!entries || entries.length === 0) return;
+
+  if (incidentSignature) {
+    const filtered = entries.filter(
+      (entry) => entry.incidentSignature !== incidentSignature,
+    );
+    if (filtered.length === 0) {
+      delete snoozedSiteMap[current];
+    } else {
+      snoozedSiteMap[current] = filtered;
+    }
+  } else {
+    delete snoozedSiteMap[current];
+  }
   await writeSnoozedSiteMap(snoozedSiteMap);
 };
 
@@ -103,16 +124,10 @@ const isCurrentSiteSnoozedUntilIncidentChanges = async (
   if (!current) return false;
 
   const snoozedSiteMap = await readSnoozedSiteMap();
-  const state = snoozedSiteMap[current];
-  if (!state) return false;
+  const entries = snoozedSiteMap[current];
+  if (!entries || entries.length === 0) return false;
 
-  if (state.incidentSignature === incidentSignature) {
-    return true;
-  }
-
-  delete snoozedSiteMap[current];
-  await writeSnoozedSiteMap(snoozedSiteMap);
-  return false;
+  return entries.some((entry) => entry.incidentSignature === incidentSignature);
 };
 
 const isWarningsEnabled = readWarningsEnabled;
@@ -302,7 +317,7 @@ const renderInlinePopup = async (
 
   const handleSnoozeUntilNewChangesClick = async () => {
     if (currentlySnoozed) {
-      await unsnoozeCurrentSiteUntilNewIncidentChanges();
+      await unsnoozeCurrentSiteUntilNewIncidentChanges(incidentSignature);
       void renderInlinePopup(matches, true);
       return;
     }

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -163,11 +163,12 @@ const Options = () => {
     if (!normalized) return;
 
     const existing = await readSnoozedSiteMap();
-    if (!Object.prototype.hasOwnProperty.call(existing, normalized)) return;
+    if (!existing[normalized] || existing[normalized].length === 0) return;
     const next = { ...existing };
     delete next[normalized];
     setSnoozedSites(
       Object.keys(next)
+        .filter((key) => next[key] && next[key].length > 0)
         .map((value) => normalizeHostname(value))
         .filter((value) => value.length > 0)
         .sort((left, right) => left.localeCompare(right)),

--- a/src/shared/snoozedSites.ts
+++ b/src/shared/snoozedSites.ts
@@ -3,7 +3,9 @@ export type SnoozedSiteState = {
   snoozedAt: number;
 };
 
-export type SnoozedSiteMap = Record<string, SnoozedSiteState>;
+export type SnoozedSiteMap = Record<string, SnoozedSiteState[]>;
+
+const MAX_SNOOZE_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 
 const isObjectRecord = (value: unknown): value is Record<string, unknown> => {
   return typeof value === "object" && value !== null;
@@ -20,19 +22,42 @@ const decodeSnoozedSiteState = (value: unknown): SnoozedSiteState | null => {
   };
 };
 
+const normalizeDomain = (domain: string): string => {
+  return domain
+    .trim()
+    .toLowerCase()
+    .replace(/^www\./, "");
+};
+
 export const normalizeSnoozedSiteMap = (value: unknown): SnoozedSiteMap => {
   if (!isObjectRecord(value)) return {};
 
+  const now = Date.now();
   const next: SnoozedSiteMap = {};
-  for (const [domain, rawState] of Object.entries(value)) {
-    const state = decodeSnoozedSiteState(rawState);
-    if (!state) continue;
-    const normalizedDomain = domain
-      .trim()
-      .toLowerCase()
-      .replace(/^www\./, "");
+
+  for (const [domain, rawValue] of Object.entries(value)) {
+    const normalizedDomain = normalizeDomain(domain);
     if (!normalizedDomain) continue;
-    next[normalizedDomain] = state;
+
+    let entries: SnoozedSiteState[];
+
+    if (Array.isArray(rawValue)) {
+      entries = rawValue
+        .map((item) => decodeSnoozedSiteState(item))
+        .filter((state): state is SnoozedSiteState => state !== null);
+    } else {
+      const state = decodeSnoozedSiteState(rawValue);
+      entries = state ? [state] : [];
+    }
+
+    const fresh = entries.filter(
+      (entry) => now - entry.snoozedAt < MAX_SNOOZE_AGE_MS,
+    );
+
+    if (fresh.length > 0) {
+      const existing = next[normalizedDomain];
+      next[normalizedDomain] = existing ? [...existing, ...fresh] : fresh;
+    }
   }
 
   return next;

--- a/tests/snoozeCrossTabs.test.ts
+++ b/tests/snoozeCrossTabs.test.ts
@@ -8,17 +8,6 @@ import {
 import { buildIncidentSignature } from "../src/shared/incidentSignature.ts";
 import { entry } from "./helpers.ts";
 
-/**
- * These tests simulate the exact bug from GitHub issue #136:
- * Two tabs on amazon.com — one showing Amazon incidents, one showing
- * Google Pixel incidents — and verify that snoozing one tab no longer
- * causes the other tab's snooze to break.
- *
- * Since the actual snooze/unsnooze/check functions live in the content
- * script and depend on browser APIs (location.hostname, browser.storage),
- * we replicate their logic here against a plain SnoozedSiteMap object.
- */
-
 // -- Helpers that mirror content script logic without browser APIs --
 
 const snooze = (

--- a/tests/snoozeCrossTabs.test.ts
+++ b/tests/snoozeCrossTabs.test.ts
@@ -1,0 +1,253 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  type SnoozedSiteMap,
+  normalizeSnoozedSiteMap,
+} from "../src/shared/snoozedSites.ts";
+import { buildIncidentSignature } from "../src/shared/incidentSignature.ts";
+import { entry } from "./helpers.ts";
+
+/**
+ * These tests simulate the exact bug from GitHub issue #136:
+ * Two tabs on amazon.com — one showing Amazon incidents, one showing
+ * Google Pixel incidents — and verify that snoozing one tab no longer
+ * causes the other tab's snooze to break.
+ *
+ * Since the actual snooze/unsnooze/check functions live in the content
+ * script and depend on browser APIs (location.hostname, browser.storage),
+ * we replicate their logic here against a plain SnoozedSiteMap object.
+ */
+
+// -- Helpers that mirror content script logic without browser APIs --
+
+const snooze = (
+  map: SnoozedSiteMap,
+  hostname: string,
+  signature: string,
+): SnoozedSiteMap => {
+  const next = { ...map };
+  const entries = [...(next[hostname] || [])];
+  const idx = entries.findIndex((e) => e.incidentSignature === signature);
+  if (idx >= 0) {
+    entries[idx] = { incidentSignature: signature, snoozedAt: Date.now() };
+  } else {
+    entries.push({ incidentSignature: signature, snoozedAt: Date.now() });
+  }
+  next[hostname] = entries;
+  return next;
+};
+
+const unsnooze = (
+  map: SnoozedSiteMap,
+  hostname: string,
+  signature?: string,
+): SnoozedSiteMap => {
+  const next = { ...map };
+  const entries = next[hostname];
+  if (!entries || entries.length === 0) return next;
+
+  if (signature) {
+    const filtered = entries.filter((e) => e.incidentSignature !== signature);
+    if (filtered.length === 0) {
+      delete next[hostname];
+    } else {
+      next[hostname] = filtered;
+    }
+  } else {
+    delete next[hostname];
+  }
+  return next;
+};
+
+const isSnoozed = (
+  map: SnoozedSiteMap,
+  hostname: string,
+  signature: string,
+): boolean => {
+  const entries = map[hostname];
+  if (!entries || entries.length === 0) return false;
+  return entries.some((e) => e.incidentSignature === signature);
+};
+
+// -- Build realistic incident signatures --
+
+const amazonSignature = buildIncidentSignature([
+  entry({
+    _type: "Incident",
+    PageID: "incident-amazon-outage",
+    PageName: "Amazon Outage",
+    Status: "Active",
+  }),
+]);
+
+const googleSignature = buildIncidentSignature([
+  entry({
+    _type: "Incident",
+    PageID: "incident-google-pixel-recall",
+    PageName: "Pixel Recall",
+    Status: "Active",
+  }),
+]);
+
+const amazonNewSignature = buildIncidentSignature([
+  entry({
+    _type: "Incident",
+    PageID: "incident-amazon-outage",
+    PageName: "Amazon Outage",
+    Status: "Active",
+  }),
+  entry({
+    _type: "Incident",
+    PageID: "incident-amazon-breach",
+    PageName: "Amazon Data Breach",
+    Status: "Active",
+  }),
+]);
+
+// -- Tests --
+
+test("two tabs on same hostname can snooze independently", () => {
+  let map: SnoozedSiteMap = {};
+
+  // Tab A (amazon.com homepage) snoozes Amazon incidents
+  map = snooze(map, "amazon.com", amazonSignature);
+  assert.equal(isSnoozed(map, "amazon.com", amazonSignature), true);
+  assert.equal(isSnoozed(map, "amazon.com", googleSignature), false);
+
+  // Tab B (amazon.com/Google-Pixel page) snoozes Google incidents
+  map = snooze(map, "amazon.com", googleSignature);
+  assert.equal(isSnoozed(map, "amazon.com", amazonSignature), true);
+  assert.equal(isSnoozed(map, "amazon.com", googleSignature), true);
+
+  // Both entries coexist
+  assert.equal(map["amazon.com"].length, 2);
+});
+
+test("unsnoozing one tab does not affect the other tab", () => {
+  let map: SnoozedSiteMap = {};
+
+  // Both tabs snoozed
+  map = snooze(map, "amazon.com", amazonSignature);
+  map = snooze(map, "amazon.com", googleSignature);
+  assert.equal(map["amazon.com"].length, 2);
+
+  // Tab B clicks "Resume alerts" — only removes Google signature
+  map = unsnooze(map, "amazon.com", googleSignature);
+  assert.equal(isSnoozed(map, "amazon.com", amazonSignature), true);
+  assert.equal(isSnoozed(map, "amazon.com", googleSignature), false);
+  assert.equal(map["amazon.com"].length, 1);
+});
+
+test("snooze check does not write to storage (no cascading deletes)", () => {
+  let map: SnoozedSiteMap = {};
+
+  // Tab A snoozed with Amazon signature
+  map = snooze(map, "amazon.com", amazonSignature);
+
+  // Tab B checks with a DIFFERENT signature — just returns false, map unchanged
+  const before = JSON.stringify(map);
+  const result = isSnoozed(map, "amazon.com", googleSignature);
+  const after = JSON.stringify(map);
+
+  assert.equal(result, false);
+  assert.equal(before, after, "map must not be mutated by isSnoozed check");
+});
+
+test("new incident causes auto-expire (signature mismatch)", () => {
+  let map: SnoozedSiteMap = {};
+
+  // Snooze with current Amazon incidents
+  map = snooze(map, "amazon.com", amazonSignature);
+  assert.equal(isSnoozed(map, "amazon.com", amazonSignature), true);
+
+  // New incident arrives — signature changes
+  assert.notEqual(amazonSignature, amazonNewSignature);
+  assert.equal(isSnoozed(map, "amazon.com", amazonNewSignature), false);
+
+  // Old entry still in storage (harmless zombie, cleaned up after 30 days)
+  assert.equal(map["amazon.com"].length, 1);
+});
+
+test("suppress site clears all snooze entries for that hostname", () => {
+  let map: SnoozedSiteMap = {};
+
+  // Multiple snooze entries
+  map = snooze(map, "amazon.com", amazonSignature);
+  map = snooze(map, "amazon.com", googleSignature);
+  assert.equal(map["amazon.com"].length, 2);
+
+  // Suppress = unsnooze with no signature
+  map = unsnooze(map, "amazon.com");
+  assert.equal(map["amazon.com"], undefined);
+});
+
+test("re-snoozing same signature refreshes timestamp without duplicating", () => {
+  let map: SnoozedSiteMap = {};
+
+  map = snooze(map, "amazon.com", amazonSignature);
+  assert.equal(map["amazon.com"].length, 1);
+  const firstTimestamp = map["amazon.com"][0].snoozedAt;
+
+  // Small delay to ensure different timestamp
+  const later = Date.now() + 1000;
+  const entries = [...(map["amazon.com"] || [])];
+  const idx = entries.findIndex(
+    (e) => e.incidentSignature === amazonSignature,
+  );
+  entries[idx] = { incidentSignature: amazonSignature, snoozedAt: later };
+  map = { ...map, "amazon.com": entries };
+
+  assert.equal(map["amazon.com"].length, 1, "no duplicate entry");
+  assert.equal(map["amazon.com"][0].snoozedAt > firstTimestamp, true);
+});
+
+test("different hostnames (amazon.com vs amazon.in) are fully independent", () => {
+  let map: SnoozedSiteMap = {};
+
+  map = snooze(map, "amazon.com", amazonSignature);
+  map = snooze(map, "amazon.in", googleSignature);
+
+  assert.equal(isSnoozed(map, "amazon.com", amazonSignature), true);
+  assert.equal(isSnoozed(map, "amazon.com", googleSignature), false);
+  assert.equal(isSnoozed(map, "amazon.in", googleSignature), true);
+  assert.equal(isSnoozed(map, "amazon.in", amazonSignature), false);
+
+  // Unsnooze amazon.com doesn't affect amazon.in
+  map = unsnooze(map, "amazon.com", amazonSignature);
+  assert.equal(map["amazon.com"], undefined);
+  assert.equal(isSnoozed(map, "amazon.in", googleSignature), true);
+});
+
+test("old storage format (single object) migrates correctly and is snoozed", () => {
+  // Simulate old format from before the fix
+  const oldStorage = {
+    "amazon.com": {
+      incidentSignature: amazonSignature,
+      snoozedAt: Date.now(),
+    },
+  };
+
+  const map = normalizeSnoozedSiteMap(oldStorage);
+
+  // Migrated to array
+  assert.equal(Array.isArray(map["amazon.com"]), true);
+  assert.equal(map["amazon.com"].length, 1);
+
+  // Still recognized as snoozed
+  assert.equal(isSnoozed(map, "amazon.com", amazonSignature), true);
+});
+
+test("settings page remove clears hostname regardless of entry count", () => {
+  let map: SnoozedSiteMap = {};
+
+  map = snooze(map, "amazon.com", amazonSignature);
+  map = snooze(map, "amazon.com", googleSignature);
+  map = snooze(map, "google.com", googleSignature);
+
+  // Settings page removes by hostname (no signature)
+  map = unsnooze(map, "amazon.com");
+
+  assert.equal(map["amazon.com"], undefined);
+  assert.equal(isSnoozed(map, "google.com", googleSignature), true);
+});

--- a/tests/snoozedSites.test.ts
+++ b/tests/snoozedSites.test.ts
@@ -1,0 +1,125 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { normalizeSnoozedSiteMap } from "../src/shared/snoozedSites.ts";
+
+test("normalizeSnoozedSiteMap returns empty map for non-object input", () => {
+  assert.deepEqual(normalizeSnoozedSiteMap(null), {});
+  assert.deepEqual(normalizeSnoozedSiteMap(undefined), {});
+  assert.deepEqual(normalizeSnoozedSiteMap("string"), {});
+  assert.deepEqual(normalizeSnoozedSiteMap(42), {});
+});
+
+test("normalizeSnoozedSiteMap migrates old single-object format to array", () => {
+  const old = {
+    "amazon.com": { incidentSignature: "inc-a|active", snoozedAt: Date.now() },
+    "google.com": {
+      incidentSignature: "inc-b|resolved",
+      snoozedAt: Date.now(),
+    },
+  };
+
+  const result = normalizeSnoozedSiteMap(old);
+
+  assert.equal(Array.isArray(result["amazon.com"]), true);
+  assert.equal(result["amazon.com"].length, 1);
+  assert.equal(result["amazon.com"][0].incidentSignature, "inc-a|active");
+
+  assert.equal(Array.isArray(result["google.com"]), true);
+  assert.equal(result["google.com"].length, 1);
+  assert.equal(result["google.com"][0].incidentSignature, "inc-b|resolved");
+});
+
+test("normalizeSnoozedSiteMap preserves new array format", () => {
+  const now = Date.now();
+  const input = {
+    "amazon.com": [
+      { incidentSignature: "inc-a|active", snoozedAt: now },
+      { incidentSignature: "inc-b|active", snoozedAt: now },
+    ],
+  };
+
+  const result = normalizeSnoozedSiteMap(input);
+
+  assert.equal(result["amazon.com"].length, 2);
+  assert.equal(result["amazon.com"][0].incidentSignature, "inc-a|active");
+  assert.equal(result["amazon.com"][1].incidentSignature, "inc-b|active");
+});
+
+test("normalizeSnoozedSiteMap normalizes domain keys", () => {
+  const now = Date.now();
+  const input = {
+    "WWW.Example.COM": [
+      { incidentSignature: "inc-a|active", snoozedAt: now },
+    ],
+    "  shop.test.com  ": [
+      { incidentSignature: "inc-b|active", snoozedAt: now },
+    ],
+  };
+
+  const result = normalizeSnoozedSiteMap(input);
+
+  assert.equal(result["example.com"]?.length, 1);
+  assert.equal(result["shop.test.com"]?.length, 1);
+  assert.equal(result["WWW.Example.COM"], undefined);
+});
+
+test("normalizeSnoozedSiteMap prunes entries older than 30 days", () => {
+  const now = Date.now();
+  const thirtyOneDaysAgo = now - 31 * 24 * 60 * 60 * 1000;
+  const oneDayAgo = now - 1 * 24 * 60 * 60 * 1000;
+
+  const input = {
+    "amazon.com": [
+      { incidentSignature: "old-sig", snoozedAt: thirtyOneDaysAgo },
+      { incidentSignature: "fresh-sig", snoozedAt: oneDayAgo },
+    ],
+    "stale.com": [
+      { incidentSignature: "ancient-sig", snoozedAt: thirtyOneDaysAgo },
+    ],
+  };
+
+  const result = normalizeSnoozedSiteMap(input);
+
+  assert.equal(result["amazon.com"].length, 1);
+  assert.equal(result["amazon.com"][0].incidentSignature, "fresh-sig");
+  assert.equal(result["stale.com"], undefined);
+});
+
+test("normalizeSnoozedSiteMap skips invalid entries in arrays", () => {
+  const now = Date.now();
+  const input = {
+    "example.com": [
+      { incidentSignature: "valid", snoozedAt: now },
+      { incidentSignature: 123, snoozedAt: now },
+      { bad: "entry" },
+      null,
+      "string",
+      { incidentSignature: "also-valid", snoozedAt: now },
+    ],
+  };
+
+  const result = normalizeSnoozedSiteMap(input);
+
+  assert.equal(result["example.com"].length, 2);
+  assert.equal(result["example.com"][0].incidentSignature, "valid");
+  assert.equal(result["example.com"][1].incidentSignature, "also-valid");
+});
+
+test("normalizeSnoozedSiteMap merges duplicate normalized domains", () => {
+  const now = Date.now();
+  const input = {
+    "www.example.com": [
+      { incidentSignature: "sig-a", snoozedAt: now },
+    ],
+    "Example.com": [
+      { incidentSignature: "sig-b", snoozedAt: now },
+    ],
+  };
+
+  const result = normalizeSnoozedSiteMap(input);
+
+  assert.equal(result["example.com"].length, 2);
+  const sigs = result["example.com"].map((e) => e.incidentSignature).sort();
+  assert.deepEqual(sigs, ["sig-a", "sig-b"]);
+});


### PR DESCRIPTION
Fixes #133

## Problem

When two tabs are open on the same domain (e.g. `amazon.com` homepage and `amazon.com/Google-Pixel...`), clicking "Hide until new incidents" causes the popup to disappear and instantly reappear.

This also affects single-tab navigation: snoozing on `amazon.com`, then searching for a product like "Google Pixel", or clicking into a product page causes the popup to come back because the new page shows different incidents than the one you snoozed on.

**Root cause:** The snooze map stores one entry per hostname. Different pages on the same hostname show different companies/incidents, so they produce different signatures. When a new page loads with a different signature, the old code treated this as "incidents have changed" and deleted the snooze entry entirely. With two tabs open, this created a cascading loop where each tab would delete the other's snooze, causing the popup to disappear and reappear instantly.

## Fix

- Changed the snooze map from one entry per hostname to an **array of entries** per hostname, so different pages on the same domain can snooze independently
- The snooze check is now read-only — it no longer deletes entries on signature mismatch, which stops the cascading loop between tabs and the single-tab navigation issue
- "Resume alerts" now only removes the current page's snooze entry, leaving other pages on the same hostname unaffected
- Old storage format (single object per hostname) is automatically migrated to the new array format, so existing users don't lose their snoozes
- Stale entries older than 30 days are cleaned up automatically

## Test plan

- [x] All 105 tests pass (89 existing + 7 new storage migration tests + 9 new cross-tab scenario tests)
- [x] Both Chrome and Firefox builds succeed
- [x] Manually tested on Firefox — snoozing works correctly on `amazon.com` homepage and product pages simultaneously
- [x] Manually tested single-tab navigation — snooze persists when navigating between pages on the same domain
- [x] Test on Chrome
- [x] Test with existing snoozed sites (upgrade path from old format)