### PR TITLE
fix: remove default body margin on options.html

### DIFF
--- a/options.html
+++ b/options.html
@@ -4,6 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CRW Extension Options</title>
+    <style>
+      body {
+        margin: 0;
+      }
+    </style>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
before:
<img width="1920" height="1032" alt="{1439E550-4F6A-471E-B798-BEDBA8924004}" src="https://github.com/user-attachments/assets/2bf863d6-ca2b-4fac-9fa5-844440c1abf6" />
after:
<img width="1920" height="1032" alt="{BCFC4E6E-FDDD-4908-93EB-07BF6C18BD54}" src="https://github.com/user-attachments/assets/a999007e-0389-4d54-98b0-aa5f5bf090c4" />
