### PR TITLE
Fix inline popup placement on mobile and tablet devices

### DIFF
--- a/src/content/InlineEmptyState.tsx
+++ b/src/content/InlineEmptyState.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 
+import { getCurrentPopupPlacementStyle } from "@/content/popupPlacement";
+
 type InlineEmptyStateProps = {
   logoUrl: string;
   settingsIconUrl: string;
@@ -9,16 +11,12 @@ type InlineEmptyStateProps = {
 
 export const InlineEmptyState = (props: InlineEmptyStateProps) => {
   const { logoUrl, settingsIconUrl, onOpenSettings, onClose } = props;
+  const containerStyle = getCurrentPopupPlacementStyle();
 
   return (
     <div
       style={{
-        position: "fixed",
-        right: "16px",
-        top: "16px",
-        width: "460px",
-        maxWidth: "calc(100vw - 32px)",
-        zIndex: 2147483647,
+        ...containerStyle,
         background: "#004080",
         color: "#FFFFFF",
         border: "1px solid rgba(255,255,255,0.25)",

--- a/src/content/InlinePopup.tsx
+++ b/src/content/InlinePopup.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import { CargoEntry } from "@/shared/types";
 import { MatchPopupCard } from "@/shared/ui/MatchPopupCard";
+import { getCurrentPopupPlacementStyle } from "@/content/popupPlacement";
 
 type InlinePopupProps = {
   matches: CargoEntry[];
@@ -40,6 +41,8 @@ export const InlinePopup = (props: InlinePopupProps) => {
     disableWarningsLabel,
   } = props;
 
+  const containerStyle = getCurrentPopupPlacementStyle();
+
   return (
     <MatchPopupCard
       matches={matches}
@@ -60,12 +63,7 @@ export const InlinePopup = (props: InlinePopupProps) => {
       showCloseButton
       hideRelatedButtonWhenEmpty
       containerStyle={{
-        position: "fixed",
-        right: "16px",
-        top: "16px",
-        width: "460px",
-        maxWidth: "calc(100vw - 32px)",
-        zIndex: 2147483647,
+        ...containerStyle,
         maxHeight: "60vh",
       }}
     />

--- a/src/content/popupPlacement.ts
+++ b/src/content/popupPlacement.ts
@@ -1,0 +1,76 @@
+import React from "react";
+
+const POPUP_EDGE_OFFSET_PX = 16;
+const TABLET_MAX_WIDTH_PX = 1024;
+
+type PopupPlacementEnvironment = {
+  userAgent?: string;
+  maxTouchPoints?: number;
+  hasCoarsePointer?: boolean;
+  viewportWidth?: number;
+  viewportHeight?: number;
+};
+
+const MOBILE_OR_TABLET_USER_AGENT =
+  /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini|Mobile|Tablet|Silk|Kindle/i;
+
+const isMobileOrTabletEnvironment = ({
+  userAgent = "",
+  maxTouchPoints = 0,
+  hasCoarsePointer = false,
+  viewportWidth = Number.POSITIVE_INFINITY,
+  viewportHeight = Number.POSITIVE_INFINITY,
+}: PopupPlacementEnvironment): boolean => {
+  if (MOBILE_OR_TABLET_USER_AGENT.test(userAgent)) return true;
+
+  const hasTouchInput = maxTouchPoints > 0;
+  const withinTabletBounds =
+    Math.min(viewportWidth, viewportHeight) <= TABLET_MAX_WIDTH_PX;
+  return hasCoarsePointer && hasTouchInput && withinTabletBounds;
+};
+
+export const shouldPlacePopupAtBottom = (
+  environment: PopupPlacementEnvironment = {},
+): boolean => {
+  return isMobileOrTabletEnvironment(environment);
+};
+
+export const getInlinePopupPlacementStyle = (
+  environment: PopupPlacementEnvironment = {},
+): React.CSSProperties => {
+  const baseStyle: React.CSSProperties = {
+    position: "fixed",
+    width: "460px",
+    maxWidth: "calc(100vw - 32px)",
+    zIndex: 2147483647,
+  };
+
+  if (!shouldPlacePopupAtBottom(environment)) {
+    return {
+      ...baseStyle,
+      right: `${POPUP_EDGE_OFFSET_PX}px`,
+      top: `${POPUP_EDGE_OFFSET_PX}px`,
+    };
+  }
+
+  return {
+    ...baseStyle,
+    left: "50%",
+    bottom: `${POPUP_EDGE_OFFSET_PX}px`,
+    transform: "translateX(-50%)",
+  };
+};
+
+export const getCurrentPopupPlacementStyle = (): React.CSSProperties => {
+  if (typeof window === "undefined" || typeof navigator === "undefined") {
+    return getInlinePopupPlacementStyle();
+  }
+
+  return getInlinePopupPlacementStyle({
+    userAgent: navigator.userAgent,
+    maxTouchPoints: navigator.maxTouchPoints,
+    hasCoarsePointer: window.matchMedia("(pointer: coarse)").matches,
+    viewportWidth: window.innerWidth,
+    viewportHeight: window.innerHeight,
+  });
+};

--- a/tests/popupPlacement.test.ts
+++ b/tests/popupPlacement.test.ts
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  getInlinePopupPlacementStyle,
+  shouldPlacePopupAtBottom,
+} from "../src/content/popupPlacement.ts";
+
+test("popup stays top-right on desktop environments", () => {
+  const environment = {
+    userAgent:
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36",
+    maxTouchPoints: 0,
+    hasCoarsePointer: false,
+    viewportWidth: 1440,
+    viewportHeight: 900,
+  };
+  const style = getInlinePopupPlacementStyle({
+    ...environment,
+  });
+
+  assert.equal(shouldPlacePopupAtBottom(environment), false);
+  assert.equal(style.top, "16px");
+  assert.equal(style.right, "16px");
+  assert.equal(style.bottom, undefined);
+  assert.equal(style.left, undefined);
+  assert.equal(style.transform, undefined);
+});
+
+test("popup moves to bottom-center on Android phones", () => {
+  const style = getInlinePopupPlacementStyle({
+    userAgent:
+      "Mozilla/5.0 (Android 14; Mobile; rv:137.0) Gecko/137.0 Firefox/137.0",
+    maxTouchPoints: 5,
+    hasCoarsePointer: true,
+    viewportWidth: 412,
+    viewportHeight: 915,
+  });
+
+  assert.equal(style.bottom, "16px");
+  assert.equal(style.left, "50%");
+  assert.equal(style.transform, "translateX(-50%)");
+  assert.equal(style.top, undefined);
+  assert.equal(style.right, undefined);
+});
+
+test("popup moves to bottom-center on touch tablets even without a mobile user agent token", () => {
+  const style = getInlinePopupPlacementStyle({
+    userAgent:
+      "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36",
+    maxTouchPoints: 10,
+    hasCoarsePointer: true,
+    viewportWidth: 1024,
+    viewportHeight: 1366,
+  });
+
+  assert.equal(style.bottom, "16px");
+  assert.equal(style.left, "50%");
+  assert.equal(style.transform, "translateX(-50%)");
+});
+
+test("popup stays top-right on touch laptops with a fine pointer", () => {
+  const style = getInlinePopupPlacementStyle({
+    userAgent:
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36",
+    maxTouchPoints: 10,
+    hasCoarsePointer: false,
+    viewportWidth: 1440,
+    viewportHeight: 900,
+  });
+
+  assert.equal(style.top, "16px");
+  assert.equal(style.right, "16px");
+  assert.equal(style.bottom, undefined);
+  assert.equal(style.left, undefined);
+});


### PR DESCRIPTION
## Summary
- centralize inline popup positioning in a shared content helper
- keep desktop behavior unchanged with top-right placement
- move popup and empty-state cards to bottom-center on phones and tablets
- add a safe fallback for non-browser render environments
- cover desktop, phone, tablet, and touch-laptop placement cases with tests

## Testing
- `npm test`
- `npm run build`