### PR TITLE
Add popup position setting (4 corners) to Options page

### DIFF
--- a/src/content/InlineEmptyState.tsx
+++ b/src/content/InlineEmptyState.tsx
@@ -1,17 +1,19 @@
 import React from "react";
 
+import type { PopupPosition } from "@/shared/constants";
 import { getCurrentPopupPlacementStyle } from "@/content/popupPlacement";
 
 type InlineEmptyStateProps = {
   logoUrl: string;
   settingsIconUrl: string;
+  position: PopupPosition;
   onOpenSettings: () => void;
   onClose: () => void;
 };
 
 export const InlineEmptyState = (props: InlineEmptyStateProps) => {
-  const { logoUrl, settingsIconUrl, onOpenSettings, onClose } = props;
-  const containerStyle = getCurrentPopupPlacementStyle();
+  const { logoUrl, settingsIconUrl, position, onOpenSettings, onClose } = props;
+  const containerStyle = getCurrentPopupPlacementStyle(position);
 
   return (
     <div

--- a/src/content/InlinePopup.tsx
+++ b/src/content/InlinePopup.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import type { PopupPosition } from "@/shared/constants";
 import { CargoEntry } from "@/shared/types";
 import { MatchPopupCard } from "@/shared/ui/MatchPopupCard";
 import { getCurrentPopupPlacementStyle } from "@/content/popupPlacement";
@@ -10,6 +11,7 @@ type InlinePopupProps = {
   externalIconUrl: string;
   settingsIconUrl: string;
   closeIconUrl: string;
+  position: PopupPosition;
   onClose: () => void;
   onOpenSettings: () => void;
   onSuppressSite: () => void;
@@ -29,6 +31,7 @@ export const InlinePopup = (props: InlinePopupProps) => {
     externalIconUrl,
     settingsIconUrl,
     closeIconUrl,
+    position,
     onClose,
     onOpenSettings,
     onSuppressSite,
@@ -41,7 +44,7 @@ export const InlinePopup = (props: InlinePopupProps) => {
     disableWarningsLabel,
   } = props;
 
-  const containerStyle = getCurrentPopupPlacementStyle();
+  const containerStyle = getCurrentPopupPlacementStyle(position);
 
   return (
     <MatchPopupCard

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -3,6 +3,8 @@ import { createRoot, type Root } from "react-dom/client";
 import browser from "webextension-polyfill";
 
 import * as Constants from "@/shared/constants";
+import { DEFAULT_POPUP_POSITION } from "@/shared/constants";
+import type { PopupPosition } from "@/shared/constants";
 import { buildIncidentSignature } from "@/shared/incidentSignature";
 import {
   getSiteScopeHostname,
@@ -12,6 +14,7 @@ import {
 import { CargoEntry, PageContext } from "@/shared/types";
 import {
   readHideWhenNoIncidents,
+  readPopupPosition,
   readSnoozedSiteMap,
   readSuppressedDomains,
   readWarningsEnabled,
@@ -273,12 +276,14 @@ const renderInlinePopup = async (
   }
 
   forcePopupVisible = ignorePreferences;
+  const popupPosition = await readPopupPosition();
   const root = ensurePopupRoot();
   if (visibleMatches.length === 0) {
     root.render(
       <InlineEmptyState
         logoUrl={ASSET_URLS.logo}
         settingsIconUrl={ASSET_URLS.settings}
+        position={popupPosition}
         onOpenSettings={openOptions}
         onClose={removeInlinePopup}
       />,
@@ -326,6 +331,7 @@ const renderInlinePopup = async (
       externalIconUrl={ASSET_URLS.external}
       settingsIconUrl={ASSET_URLS.settings}
       closeIconUrl={ASSET_URLS.close}
+      position={popupPosition}
       onClose={removeInlinePopup}
       onOpenSettings={openOptions}
       onDisableWarnings={() => void handleDisableWarnings()}

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -3,7 +3,6 @@ import { createRoot, type Root } from "react-dom/client";
 import browser from "webextension-polyfill";
 
 import * as Constants from "@/shared/constants";
-import { DEFAULT_POPUP_POSITION } from "@/shared/constants";
 import type { PopupPosition } from "@/shared/constants";
 import { buildIncidentSignature } from "@/shared/incidentSignature";
 import {
@@ -276,7 +275,7 @@ const renderInlinePopup = async (
   }
 
   forcePopupVisible = ignorePreferences;
-  const popupPosition = await readPopupPosition();
+  const popupPosition: PopupPosition = await readPopupPosition();
   const root = ensurePopupRoot();
   if (visibleMatches.length === 0) {
     root.render(

--- a/src/content/popupPlacement.ts
+++ b/src/content/popupPlacement.ts
@@ -1,5 +1,8 @@
 import React from "react";
 
+import type { PopupPosition } from "@/shared/constants";
+import { DEFAULT_POPUP_POSITION } from "@/shared/constants";
+
 const POPUP_EDGE_OFFSET_PX = 16;
 const TABLET_MAX_WIDTH_PX = 1024;
 
@@ -36,6 +39,7 @@ export const shouldPlacePopupAtBottom = (
 };
 
 export const getInlinePopupPlacementStyle = (
+  position: PopupPosition = DEFAULT_POPUP_POSITION,
   environment: PopupPlacementEnvironment = {},
 ): React.CSSProperties => {
   const baseStyle: React.CSSProperties = {
@@ -45,28 +49,37 @@ export const getInlinePopupPlacementStyle = (
     zIndex: 2147483647,
   };
 
-  if (!shouldPlacePopupAtBottom(environment)) {
+  if (shouldPlacePopupAtBottom(environment)) {
     return {
       ...baseStyle,
-      right: `${POPUP_EDGE_OFFSET_PX}px`,
-      top: `${POPUP_EDGE_OFFSET_PX}px`,
+      left: "50%",
+      bottom: `${POPUP_EDGE_OFFSET_PX}px`,
+      transform: "translateX(-50%)",
     };
   }
 
+  const isBottom = position === "bottom-left" || position === "bottom-right";
+  const isLeft = position === "top-left" || position === "bottom-left";
+
   return {
     ...baseStyle,
-    left: "50%",
-    bottom: `${POPUP_EDGE_OFFSET_PX}px`,
-    transform: "translateX(-50%)",
+    ...(isBottom
+      ? { bottom: `${POPUP_EDGE_OFFSET_PX}px` }
+      : { top: `${POPUP_EDGE_OFFSET_PX}px` }),
+    ...(isLeft
+      ? { left: `${POPUP_EDGE_OFFSET_PX}px` }
+      : { right: `${POPUP_EDGE_OFFSET_PX}px` }),
   };
 };
 
-export const getCurrentPopupPlacementStyle = (): React.CSSProperties => {
+export const getCurrentPopupPlacementStyle = (
+  position: PopupPosition = DEFAULT_POPUP_POSITION,
+): React.CSSProperties => {
   if (typeof window === "undefined" || typeof navigator === "undefined") {
-    return getInlinePopupPlacementStyle();
+    return getInlinePopupPlacementStyle(position);
   }
 
-  return getInlinePopupPlacementStyle({
+  return getInlinePopupPlacementStyle(position, {
     userAgent: navigator.userAgent,
     maxTouchPoints: navigator.maxTouchPoints,
     hasCoarsePointer: window.matchMedia("(pointer: coarse)").matches,

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -53,7 +53,9 @@ const Options = () => {
   const [refreshingNow, setRefreshingNow] = useState<boolean>(false);
   const [refreshError, setRefreshError] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
-  const [popupPosition, setPopupPosition] = useState<PopupPosition>(DEFAULT_POPUP_POSITION);
+  const [popupPosition, setPopupPosition] = useState<PopupPosition>(
+    DEFAULT_POPUP_POSITION,
+  );
 
   useEffect(() => {
     void (async () => {

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from "react";
 import browser from "webextension-polyfill";
 
 import * as Constants from "@/shared/constants";
+import type { PopupPosition } from "@/shared/constants";
+import { DEFAULT_POPUP_POSITION } from "@/shared/constants";
 import { OptionsView } from "@/options/OptionsView";
 import * as Messaging from "@/messaging";
 import { MessageType } from "@/messaging/type";
@@ -9,12 +11,14 @@ import { normalizeHostname } from "@/shared/siteScope";
 import {
   readHideWhenNoIncidents,
   readLastRefreshedAt,
+  readPopupPosition,
   readRefreshErrorMessage,
   readRefreshIntervalMs,
   readSnoozedSiteMap,
   readSuppressedDomains,
   readWarningsEnabled,
   writeHideWhenNoIncidents,
+  writePopupPosition,
   writeSnoozedSiteMap,
   writeSuppressedDomains,
   writeWarningsEnabled,
@@ -49,6 +53,7 @@ const Options = () => {
   const [refreshingNow, setRefreshingNow] = useState<boolean>(false);
   const [refreshError, setRefreshError] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
+  const [popupPosition, setPopupPosition] = useState<PopupPosition>(DEFAULT_POPUP_POSITION);
 
   useEffect(() => {
     void (async () => {
@@ -61,6 +66,7 @@ const Options = () => {
           intervalMs,
           refreshedAt,
           fetchError,
+          position,
         ] = await Promise.all([
           readWarningsEnabled(),
           readHideWhenNoIncidents(),
@@ -69,6 +75,7 @@ const Options = () => {
           readRefreshIntervalMs(),
           readLastRefreshedAt(),
           readLastRefreshError(),
+          readPopupPosition(),
         ]);
         setWarningsEnabled(enabled);
         setHideWhenNoIncidents(hideWithoutIncidents);
@@ -77,6 +84,7 @@ const Options = () => {
         setRefreshIntervalMs(intervalMs);
         setLastRefreshedAt(refreshedAt);
         setLastRefreshError(fetchError);
+        setPopupPosition(position);
       } finally {
         setLoading(false);
       }
@@ -119,6 +127,10 @@ const Options = () => {
       if (changes[Constants.STORAGE.SNOOZED_SITES_UNTIL_INCIDENT_CHANGE]) {
         void readSnoozedSites().then(setSnoozedSites);
       }
+
+      if (changes[Constants.STORAGE.POPUP_POSITION]) {
+        void readPopupPosition().then(setPopupPosition);
+      }
     };
 
     browser.storage.onChanged.addListener(onStorageChanged);
@@ -160,6 +172,11 @@ const Options = () => {
         .sort((left, right) => left.localeCompare(right)),
     );
     await writeSnoozedSiteMap(next);
+  };
+
+  const onChangePopupPosition = async (position: PopupPosition) => {
+    setPopupPosition(position);
+    await writePopupPosition(position);
   };
 
   const onChangeRefreshInterval = async (nextRefreshIntervalMs: number) => {
@@ -208,6 +225,7 @@ const Options = () => {
       refreshError={refreshError}
       lastRefreshError={lastRefreshError}
       loading={loading}
+      popupPosition={popupPosition}
       onToggleWarnings={(enabled) => {
         void onToggleWarnings(enabled);
       }}
@@ -225,6 +243,9 @@ const Options = () => {
       }}
       onRemoveSnoozedSite={(domain) => {
         void onRemoveSnoozedSite(domain);
+      }}
+      onChangePopupPosition={(position) => {
+        void onChangePopupPosition(position);
       }}
     />
   );

--- a/src/options/OptionsView.tsx
+++ b/src/options/OptionsView.tsx
@@ -309,6 +309,8 @@ export const OptionsView = (props: OptionsViewProps) => {
           </p>
 
           <div
+            role="radiogroup"
+            aria-label="Popup position"
             style={{
               display: "grid",
               gridTemplateColumns: "1fr 1fr",
@@ -322,6 +324,8 @@ export const OptionsView = (props: OptionsViewProps) => {
                 <button
                   key={option.value}
                   type="button"
+                  role="radio"
+                  aria-checked={selected}
                   disabled={loading}
                   onClick={() => onChangePopupPosition(option.value)}
                   style={{

--- a/src/options/OptionsView.tsx
+++ b/src/options/OptionsView.tsx
@@ -19,11 +19,15 @@ const REFRESH_INTERVAL_OPTIONS = [
   { value: 7 * 24 * 60 * 60 * 1000, label: "1 week" },
 ] as const;
 
-const POPUP_POSITION_OPTIONS: { value: PopupPosition; label: string; corner: [boolean, boolean] }[] = [
-  { value: "top-left",     label: "Top left",     corner: [false, true]  },
-  { value: "top-right",    label: "Top right",    corner: [false, false] },
-  { value: "bottom-left",  label: "Bottom left",  corner: [true,  true]  },
-  { value: "bottom-right", label: "Bottom right", corner: [true,  false] },
+const POPUP_POSITION_OPTIONS: {
+  value: PopupPosition;
+  label: string;
+  corner: [boolean, boolean];
+}[] = [
+  { value: "top-left", label: "Top left", corner: [false, true] },
+  { value: "top-right", label: "Top right", corner: [false, false] },
+  { value: "bottom-left", label: "Bottom left", corner: [true, true] },
+  { value: "bottom-right", label: "Bottom right", corner: [true, false] },
 ];
 
 export type OptionsViewProps = {

--- a/src/options/OptionsView.tsx
+++ b/src/options/OptionsView.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import type { PopupPosition } from "@/shared/constants";
 
 const PAGE_CSS = {
   bg: "#004080",
@@ -18,6 +19,13 @@ const REFRESH_INTERVAL_OPTIONS = [
   { value: 7 * 24 * 60 * 60 * 1000, label: "1 week" },
 ] as const;
 
+const POPUP_POSITION_OPTIONS: { value: PopupPosition; label: string; corner: [boolean, boolean] }[] = [
+  { value: "top-left",     label: "Top left",     corner: [false, true]  },
+  { value: "top-right",    label: "Top right",    corner: [false, false] },
+  { value: "bottom-left",  label: "Bottom left",  corner: [true,  true]  },
+  { value: "bottom-right", label: "Bottom right", corner: [true,  false] },
+];
+
 export type OptionsViewProps = {
   warningsEnabled: boolean;
   hideWhenNoIncidents: boolean;
@@ -29,12 +37,14 @@ export type OptionsViewProps = {
   refreshError: string | null;
   lastRefreshError: string | null;
   loading: boolean;
+  popupPosition: PopupPosition;
   onToggleWarnings: (enabled: boolean) => void;
   onToggleHideWhenNoIncidents: (enabled: boolean) => void;
   onChangeRefreshInterval: (refreshIntervalMs: number) => void;
   onRefreshNow: () => void;
   onRemoveSuppressedDomain: (domain: string) => void;
   onRemoveSnoozedSite: (domain: string) => void;
+  onChangePopupPosition: (position: PopupPosition) => void;
 };
 
 const formatLastRefreshed = (value: number | null): string => {
@@ -61,12 +71,14 @@ export const OptionsView = (props: OptionsViewProps) => {
     refreshError,
     lastRefreshError,
     loading,
+    popupPosition,
     onToggleWarnings,
     onToggleHideWhenNoIncidents,
     onChangeRefreshInterval,
     onRefreshNow,
     onRemoveSuppressedDomain,
     onRemoveSnoozedSite,
+    onChangePopupPosition,
   } = props;
 
   return (
@@ -264,6 +276,106 @@ export const OptionsView = (props: OptionsViewProps) => {
               ? "Enabled: automatic popups are hidden unless incident matches are present."
               : "Disabled: automatic popups can show even without incident matches."}
           </p>
+        </section>
+
+        <section
+          style={{
+            border: `1px solid ${PAGE_CSS.border}`,
+            borderRadius: "12px",
+            padding: "14px",
+            background: PAGE_CSS.subtleBg,
+          }}
+        >
+          <h2
+            style={{
+              margin: 0,
+              fontSize: "16px",
+              lineHeight: 1.2,
+              fontWeight: 700,
+              color: PAGE_CSS.text,
+            }}
+          >
+            Popup Position
+          </h2>
+          <p
+            style={{
+              margin: "6px 0 10px 0",
+              fontSize: "13px",
+              color: PAGE_CSS.muted,
+            }}
+          >
+            Choose which corner of the screen the popup appears in. On mobile
+            devices it always appears at the bottom center.
+          </p>
+
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "1fr 1fr",
+              gap: "8px",
+            }}
+          >
+            {POPUP_POSITION_OPTIONS.map((option) => {
+              const [isBottom, isLeft] = option.corner;
+              const selected = popupPosition === option.value;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  disabled={loading}
+                  onClick={() => onChangePopupPosition(option.value)}
+                  style={{
+                    border: `1px solid ${selected ? PAGE_CSS.text : PAGE_CSS.border}`,
+                    borderRadius: "10px",
+                    padding: "10px",
+                    background: selected
+                      ? "rgba(255,255,255,0.18)"
+                      : "transparent",
+                    color: PAGE_CSS.text,
+                    cursor: loading ? "default" : "pointer",
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: "6px",
+                    opacity: loading ? 0.75 : 1,
+                  }}
+                >
+                  <div
+                    style={{
+                      position: "relative",
+                      width: "100%",
+                      paddingBottom: "50%",
+                      border: `1px solid ${PAGE_CSS.border}`,
+                      borderRadius: "6px",
+                      background: "rgba(0,0,0,0.2)",
+                    }}
+                  >
+                    <div
+                      style={{
+                        position: "absolute",
+                        width: "36%",
+                        height: "40%",
+                        background: selected
+                          ? PAGE_CSS.text
+                          : "rgba(255,255,255,0.5)",
+                        borderRadius: "3px",
+                        ...(isBottom ? { bottom: "6px" } : { top: "6px" }),
+                        ...(isLeft ? { left: "6px" } : { right: "6px" }),
+                      }}
+                    />
+                  </div>
+                  <div
+                    style={{
+                      fontSize: "13px",
+                      fontWeight: selected ? 700 : 400,
+                      textAlign: "center",
+                    }}
+                  >
+                    {option.label}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
         </section>
 
         <section

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -2,6 +2,9 @@ import type { CargoEntryType } from "@/shared/types";
 
 export const LOG_PREFIX = "[CRW_EXTENSION]";
 
+export type PopupPosition = "top-left" | "top-right" | "bottom-left" | "bottom-right";
+export const DEFAULT_POPUP_POSITION: PopupPosition = "top-right";
+
 export const DATA_REMOTE_URL =
   "https://raw.githubusercontent.com/FULU-Foundation/CRW-Extension/refs/heads/export_cargo/all_cargo_combined.json";
 export const DEFAULT_DATA_REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000;
@@ -31,4 +34,5 @@ export const STORAGE = {
     "crw_snoozed_sites_until_incident_change",
   HIDE_WHEN_NO_INCIDENTS: "crw_hide_when_no_incidents",
   WARNINGS_ENABLED: "crw_warnings_enabled",
+  POPUP_POSITION: "crw_popup_position",
 } as const;

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -2,7 +2,11 @@ import type { CargoEntryType } from "@/shared/types";
 
 export const LOG_PREFIX = "[CRW_EXTENSION]";
 
-export type PopupPosition = "top-left" | "top-right" | "bottom-left" | "bottom-right";
+export type PopupPosition =
+  | "top-left"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-right";
 export const DEFAULT_POPUP_POSITION: PopupPosition = "top-right";
 
 export const DATA_REMOTE_URL =

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -1,6 +1,7 @@
 import browser from "webextension-polyfill";
 
 import * as Constants from "@/shared/constants";
+import type { PopupPosition } from "@/shared/constants";
 import { canonicalizeSiteScopeList } from "@/shared/siteScope";
 import { ensureDataMigration } from "@/shared/dataMigrations";
 import { type CargoEntry, decodeCargoEntries } from "@/shared/types";
@@ -137,6 +138,26 @@ export const readRefreshErrorMessage = async (): Promise<string | null> => {
 
   const record = value as Record<string, unknown>;
   return typeof record.message === "string" ? record.message : null;
+};
+
+const isPopupPosition = (value: unknown): value is PopupPosition => {
+  return (
+    value === "top-left" ||
+    value === "top-right" ||
+    value === "bottom-left" ||
+    value === "bottom-right"
+  );
+};
+
+export const readPopupPosition = async (): Promise<PopupPosition> => {
+  const value = await readLocalValue(Constants.STORAGE.POPUP_POSITION);
+  return isPopupPosition(value) ? value : Constants.DEFAULT_POPUP_POSITION;
+};
+
+export const writePopupPosition = async (
+  position: PopupPosition,
+): Promise<void> => {
+  await writeLocalValue(Constants.STORAGE.POPUP_POSITION, position);
 };
 
 export const readTabMatches = async (tabId: number): Promise<CargoEntry[]> => {

--- a/tests/popupPlacement.test.ts
+++ b/tests/popupPlacement.test.ts
@@ -15,7 +15,7 @@ test("popup stays top-right on desktop environments", () => {
     viewportWidth: 1440,
     viewportHeight: 900,
   };
-  const style = getInlinePopupPlacementStyle({
+  const style = getInlinePopupPlacementStyle("top-right", {
     ...environment,
   });
 
@@ -28,7 +28,7 @@ test("popup stays top-right on desktop environments", () => {
 });
 
 test("popup moves to bottom-center on Android phones", () => {
-  const style = getInlinePopupPlacementStyle({
+  const style = getInlinePopupPlacementStyle("top-right", {
     userAgent:
       "Mozilla/5.0 (Android 14; Mobile; rv:137.0) Gecko/137.0 Firefox/137.0",
     maxTouchPoints: 5,
@@ -45,7 +45,7 @@ test("popup moves to bottom-center on Android phones", () => {
 });
 
 test("popup moves to bottom-center on touch tablets even without a mobile user agent token", () => {
-  const style = getInlinePopupPlacementStyle({
+  const style = getInlinePopupPlacementStyle("top-right", {
     userAgent:
       "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36",
     maxTouchPoints: 10,
@@ -60,7 +60,7 @@ test("popup moves to bottom-center on touch tablets even without a mobile user a
 });
 
 test("popup stays top-right on touch laptops with a fine pointer", () => {
-  const style = getInlinePopupPlacementStyle({
+  const style = getInlinePopupPlacementStyle("top-right", {
     userAgent:
       "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36",
     maxTouchPoints: 10,


### PR DESCRIPTION
## Summary

- Adds a **Popup Position** section to the Options page with a 2×2 corner picker
- Users can now choose where the inline popup appears: top-left, top-right (default), bottom-left, or bottom-right
- Default is top-right, preserving existing behaviour for users with no stored preference
- Corner picker uses a `radiogroup` + `radio` ARIA pattern so screen readers announce the group label, each option, and the currently selected position

## Changes

| File | Change |
|------|--------|
| `src/shared/constants.ts` | Added `PopupPosition` type, `DEFAULT_POPUP_POSITION`, and `POPUP_POSITION` storage key |
| `src/shared/storage.ts` | Added `readPopupPosition()` and `writePopupPosition()` |
| `src/content/popupPlacement.ts` | `getInlinePopupPlacementStyle` now takes `PopupPosition` as first arg |
| `src/content/InlinePopup.tsx` | Accepts and passes `position` prop |
| `src/content/InlineEmptyState.tsx` | Accepts and passes `position` prop |
| `src/content/index.tsx` | Reads position from storage, annotates with `PopupPosition` type, passes to inline components |
| `src/options/Options.tsx` | Loads/saves popup position state, listens for storage changes |
| `src/options/OptionsView.tsx` | Renders 2×2 grid corner picker with miniature browser-window previews; `role="radiogroup"` on container, `role="radio"` + `aria-checked` on each button |
| `tests/popupPlacement.test.ts` | Updated test calls to pass position as the new first argument |

## Test plan

- [x] Open Options page — "Popup Position" section appears below "Automatic Popup Filters"
- [x] Clicking each corner button selects it (highlighted) and persists across page refreshes
- [x] Visit a matched site — popup appears in the selected corner
- [x] Default is top-right for users with no stored preference
- [x] Screen reader announces group as "Popup position", each option label, and whether it is selected
- [x] All 115 tests pass