### PR TITLE
fix: broken build on main — normalizeHostname import in Popup and Options

### DIFF
--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -7,7 +7,7 @@ import { DEFAULT_POPUP_POSITION } from "@/shared/constants";
 import { OptionsView } from "@/options/OptionsView";
 import * as Messaging from "@/messaging";
 import { MessageType } from "@/messaging/type";
-import { normalizeHostname } from "@/shared/siteScope";
+import { normalizeHostname } from "@/shared/util";
 import {
   readHideWhenNoIncidents,
   readLastRefreshedAt,

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -4,9 +4,9 @@ import browser from "webextension-polyfill";
 import {
   getSiteScopeHostname,
   isHostnameInSiteScopeList,
-  normalizeHostname,
   removeMatchingSiteScopes,
 } from "@/shared/siteScope";
+import { normalizeHostname } from "@/shared/util";
 import { CargoEntry } from "@/shared/types";
 import {
   readSuppressedDomains,

--- a/src/shared/util.ts
+++ b/src/shared/util.ts
@@ -4,14 +4,14 @@
 
 /** Remove the start that matches `pre` */
 export const stripPrefix = (s: string, pre: string) =>
-	s.startsWith(pre) ? s.substring(pre.length) : s;
+  s.startsWith(pre) ? s.substring(pre.length) : s;
 
 /** Remove the end that matches `suf` */
 export const stripSuffix = (s: string, suf: string) =>
-	s.endsWith(suf) && suf.length !== 0 ? s.slice(0, -suf.length) : s;
+  s.endsWith(suf) && suf.length !== 0 ? s.slice(0, -suf.length) : s;
 
 export const normalizeHostname = (hostname: string): string =>
-	stripPrefix(hostname.trim().toLowerCase(), "www.");
+  stripPrefix(hostname.trim().toLowerCase(), "www.");
 
 export const splitWebsiteField = (website: unknown): string[] => {
   if (typeof website !== "string") return [];


### PR DESCRIPTION
## Summary

Hello, and thank you for maintaining this project!

While setting up a local development environment, I found that `npm run build` currently fails on `main`:

```
src/popup/Popup.tsx (7:2): "normalizeHostname" is not exported by "src/shared/siteScope.ts", imported by "src/popup/Popup.tsx".
```

Commit a071b39 (`refactor: common normalizeHostname`) moved `normalizeHostname` from `src/shared/siteScope.ts` to `src/shared/util.ts`, but the imports in `src/popup/Popup.tsx` and `src/options/Options.tsx` still referenced the old module. The test suite does not catch this because the tests do not import these UI entry points.

## Changes

- `src/popup/Popup.tsx`: import `normalizeHostname` from `@/shared/util`
- `src/options/Options.tsx`: import `normalizeHostname` from `@/shared/util`

## Verification

- `npm run build` — succeeds for both Chrome and Firefox targets
- `npm run lint` — no warnings or errors
- `npm test` — 115/115 tests passing

## Disclosure

In the spirit of transparency: this change was prepared with the assistance of an AI coding tool (Claude Code). The diagnosis and the resulting two-line change were reviewed and verified by me before submission. If the project prefers not to accept AI-assisted contributions, I completely understand — please feel free to close this PR, and thank you for your time either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
