### PR TITLE
fix: per-tab match storage never cleaned up (leak + stale badges after restart)

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -86,15 +86,26 @@ const loadDatasetCache = async (options?: {
   }
 };
 
+const clearStoredTabMatches = async (): Promise<void> => {
+  const stored = await browser.storage.local.get(null);
+  const staleKeys = Object.keys(stored).filter((key) =>
+    key.startsWith(Constants.STORAGE.MATCHES_PREFIX),
+  );
+  if (staleKeys.length === 0) return;
+  await browser.storage.local.remove(staleKeys);
+};
+
 browser.runtime.onInstalled.addListener(async () => {
   console.log(
     `${Constants.LOG_PREFIX} Extension installed/updated. Loading dataset...`,
   );
 
+  await clearStoredTabMatches();
   await loadDatasetCache();
 });
 
 browser.runtime.onStartup.addListener(async () => {
+  await clearStoredTabMatches();
   await loadDatasetCache();
 });
 
@@ -118,6 +129,10 @@ browser.tabs.onActivated.addListener(async ({ tabId }) => {
     text: getBadgeText(results.length),
   });
   browser.action.setBadgeBackgroundColor({ tabId, color: "#FF5722" });
+});
+
+browser.tabs.onRemoved.addListener((tabId) => {
+  void browser.storage.local.remove(Constants.STORAGE.MATCHES(tabId));
 });
 
 browser.action.onClicked.addListener(async (tab) => {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -25,9 +25,12 @@ export const DATASET_KEYS: CargoEntryType[] = [
   "ProductLine",
 ];
 
+const MATCHES_KEY_PREFIX = "crw_matched_";
+
 export const STORAGE = {
+  MATCHES_PREFIX: MATCHES_KEY_PREFIX,
   MATCHES: (tabId: number) => {
-    return `crw_matched_${tabId}`;
+    return `${MATCHES_KEY_PREFIX}${tabId}`;
   },
   DATASET_CACHE: "crw_dataset_cache",
   DATA_REFRESH_INTERVAL_MS: "crw_data_refresh_interval_ms",

--- a/src/shared/siteScope.ts
+++ b/src/shared/siteScope.ts
@@ -1,6 +1,8 @@
 import { getDomain } from "tldts";
 import { normalizeHostname } from "./util.ts";
 
+export { normalizeHostname };
+
 export const getSiteScopeHostname = (hostname: string): string => {
   const normalized = normalizeHostname(hostname);
   if (!normalized) return "";

--- a/src/shared/util.ts
+++ b/src/shared/util.ts
@@ -4,14 +4,14 @@
 
 /** Remove the start that matches `pre` */
 export const stripPrefix = (s: string, pre: string) =>
-	s.startsWith(pre) ? s.substring(pre.length) : s;
+  s.startsWith(pre) ? s.substring(pre.length) : s;
 
 /** Remove the end that matches `suf` */
 export const stripSuffix = (s: string, suf: string) =>
-	s.endsWith(suf) && suf.length !== 0 ? s.slice(0, -suf.length) : s;
+  s.endsWith(suf) && suf.length !== 0 ? s.slice(0, -suf.length) : s;
 
 export const normalizeHostname = (hostname: string): string =>
-	stripPrefix(hostname.trim().toLowerCase(), "www.");
+  stripPrefix(hostname.trim().toLowerCase(), "www.");
 
 export const splitWebsiteField = (website: unknown): string[] => {
   if (typeof website !== "string") return [];


### PR DESCRIPTION
## Summary

Hello again, and thank you for your work on this project!

While reviewing the storage handling, I noticed that per-tab match results (`browser.storage.local` keys of the form `crw_matched_<tabId>`) are written by the background script but never removed. There is currently no `tabs.onRemoved` listener in the codebase.

This has two consequences:

1. **Unbounded storage growth** — every tab ever opened leaves its match array (full `CargoEntry` objects) in `storage.local` permanently.
2. **Stale matches after restart** — browsers reuse tab IDs across sessions, so a fresh tab can inherit `crw_matched_<tabId>` from an unrelated site visited in a previous session. The `tabs.onActivated` handler then briefly shows a wrong badge count (and the toolbar popup shows the wrong articles) until the page context is recomputed.

## Changes

- `src/background/index.ts`
  - `tabs.onRemoved` listener removes the closed tab's match key.
  - A sweep of all `crw_matched_*` keys runs on `runtime.onInstalled` and `runtime.onStartup`, since no per-tab key from a previous session can still be valid.
- `src/shared/constants.ts`
  - The key prefix is extracted into `STORAGE.MATCHES_PREFIX` so the sweep and the key builder cannot drift apart.

## Verification

- `npm run lint` — no warnings or errors
- `npm test` — 115/115 tests passing
- Vite builds of the background and content bundles succeed. (The popup/options bundle currently fails to build on `main` for an unrelated reason — see PR #178.)

## Disclosure

In the spirit of transparency: this change was prepared with the assistance of an AI coding tool (Claude Code). The diagnosis and the resulting change were reviewed and verified by a human before submission. If the project prefers not to accept AI-assisted contributions, I completely understand — please feel free to close this PR, and thank you for your time either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
