### PR TITLE
fix: recompute matches after SPA navigation

### DIFF
--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -33,7 +33,7 @@ import {
   extractAmazonMarketplaceProperties,
   extractEbayJsonLdProductProperties,
 } from "@/lib/matching/ecommerce";
-import { createUrlChangeDetector } from "@/content/urlChangeDetector";
+import { createUrlChangeDebouncer } from "@/content/urlChangeDetector";
 
 console.log(
   `${Constants.LOG_PREFIX} Content script loaded on:`,
@@ -483,20 +483,16 @@ browser.storage.onChanged.addListener((changes, areaName) => {
   void syncPopupStateWithStorage();
 });
 
-const hasUrlChanged = createUrlChangeDetector(location.href);
-let pendingPageContextRefresh: number | null = null;
+const schedulePageContextRefreshForUrl = createUrlChangeDebouncer({
+  initialUrl: location.href,
+  delayMs: 300,
+  onRefresh: () => void runContentScript(),
+  setTimer: (callback, delayMs) => window.setTimeout(callback, delayMs),
+  clearTimer: (timer) => window.clearTimeout(timer),
+});
 
 const schedulePageContextRefresh = () => {
-  if (!hasUrlChanged(location.href)) return;
-
-  if (pendingPageContextRefresh !== null) {
-    window.clearTimeout(pendingPageContextRefresh);
-  }
-
-  pendingPageContextRefresh = window.setTimeout(() => {
-    pendingPageContextRefresh = null;
-    void runContentScript();
-  }, 300);
+  schedulePageContextRefreshForUrl(location.href);
 };
 
 window.addEventListener("popstate", schedulePageContextRefresh);

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -33,6 +33,7 @@ import {
   extractAmazonMarketplaceProperties,
   extractEbayJsonLdProductProperties,
 } from "@/lib/matching/ecommerce";
+import { createUrlChangeDetector } from "@/content/urlChangeDetector";
 
 console.log(
   `${Constants.LOG_PREFIX} Content script loaded on:`,
@@ -481,5 +482,32 @@ browser.storage.onChanged.addListener((changes, areaName) => {
 
   void syncPopupStateWithStorage();
 });
+
+const hasUrlChanged = createUrlChangeDetector(location.href);
+let pendingPageContextRefresh: number | null = null;
+
+const schedulePageContextRefresh = () => {
+  if (!hasUrlChanged(location.href)) return;
+
+  if (pendingPageContextRefresh !== null) {
+    window.clearTimeout(pendingPageContextRefresh);
+  }
+
+  pendingPageContextRefresh = window.setTimeout(() => {
+    pendingPageContextRefresh = null;
+    void runContentScript();
+  }, 300);
+};
+
+window.addEventListener("popstate", schedulePageContextRefresh);
+window.addEventListener("hashchange", schedulePageContextRefresh);
+
+const navigationObserver = new MutationObserver(schedulePageContextRefresh);
+navigationObserver.observe(document.documentElement, {
+  childList: true,
+  subtree: true,
+});
+
+window.setInterval(schedulePageContextRefresh, 1000);
 
 void runContentScript();

--- a/src/content/urlChangeDetector.ts
+++ b/src/content/urlChangeDetector.ts
@@ -1,0 +1,11 @@
+export const createUrlChangeDetector = (
+  initialUrl: string,
+): ((currentUrl: string) => boolean) => {
+  let previousUrl = initialUrl;
+
+  return (currentUrl: string): boolean => {
+    if (currentUrl === previousUrl) return false;
+    previousUrl = currentUrl;
+    return true;
+  };
+};

--- a/src/content/urlChangeDetector.ts
+++ b/src/content/urlChangeDetector.ts
@@ -9,3 +9,36 @@ export const createUrlChangeDetector = (
     return true;
   };
 };
+
+interface UrlChangeDebouncerOptions {
+  initialUrl: string;
+  delayMs: number;
+  onRefresh: () => void;
+  setTimer: (callback: () => void, delayMs: number) => number;
+  clearTimer: (timer: number) => void;
+}
+
+export const createUrlChangeDebouncer = ({
+  initialUrl,
+  delayMs,
+  onRefresh,
+  setTimer,
+  clearTimer,
+}: UrlChangeDebouncerOptions): ((currentUrl: string) => void) => {
+  const hasUrlChanged = createUrlChangeDetector(initialUrl);
+  let pendingRefresh: number | null = null;
+
+  return (currentUrl: string): void => {
+    const urlChanged = hasUrlChanged(currentUrl);
+    if (!urlChanged && pendingRefresh === null) return;
+
+    if (pendingRefresh !== null) {
+      clearTimer(pendingRefresh);
+    }
+
+    pendingRefresh = setTimer(() => {
+      pendingRefresh = null;
+      onRefresh();
+    }, delayMs);
+  };
+};

--- a/tests/urlChangeDetector.test.ts
+++ b/tests/urlChangeDetector.test.ts
@@ -1,7 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { createUrlChangeDetector } from "../src/content/urlChangeDetector.ts";
+import {
+  createUrlChangeDebouncer,
+  createUrlChangeDetector,
+} from "../src/content/urlChangeDetector.ts";
 
 test("detects a URL change only once", () => {
   const hasUrlChanged = createUrlChangeDetector("https://example.com/first");
@@ -17,4 +20,42 @@ test("detects path, query, and hash changes", () => {
   assert.equal(hasUrlChanged("https://example.com/product"), true);
   assert.equal(hasUrlChanged("https://example.com/product?id=1"), true);
   assert.equal(hasUrlChanged("https://example.com/product?id=1#details"), true);
+});
+
+test("debounces mutations while a URL refresh is pending", () => {
+  let nextTimer = 0;
+  let refreshCount = 0;
+  const timers = new Map<number, () => void>();
+  const clearedTimers: number[] = [];
+  const scheduleRefresh = createUrlChangeDebouncer({
+    initialUrl: "https://example.com/first",
+    delayMs: 300,
+    onRefresh: () => {
+      refreshCount += 1;
+    },
+    setTimer: (callback) => {
+      nextTimer += 1;
+      timers.set(nextTimer, callback);
+      return nextTimer;
+    },
+    clearTimer: (timer) => {
+      clearedTimers.push(timer);
+      timers.delete(timer);
+    },
+  });
+
+  scheduleRefresh("https://example.com/second");
+  scheduleRefresh("https://example.com/second");
+
+  assert.deepEqual(clearedTimers, [1]);
+  assert.equal(timers.has(1), false);
+  assert.equal(timers.has(2), true);
+
+  const pendingCallback = timers.get(2);
+  timers.delete(2);
+  pendingCallback?.();
+  assert.equal(refreshCount, 1);
+
+  scheduleRefresh("https://example.com/second");
+  assert.equal(timers.size, 0);
 });

--- a/tests/urlChangeDetector.test.ts
+++ b/tests/urlChangeDetector.test.ts
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createUrlChangeDetector } from "../src/content/urlChangeDetector.ts";
+
+test("detects a URL change only once", () => {
+  const hasUrlChanged = createUrlChangeDetector("https://example.com/first");
+
+  assert.equal(hasUrlChanged("https://example.com/first"), false);
+  assert.equal(hasUrlChanged("https://example.com/second"), true);
+  assert.equal(hasUrlChanged("https://example.com/second"), false);
+});
+
+test("detects path, query, and hash changes", () => {
+  const hasUrlChanged = createUrlChangeDetector("https://example.com/");
+
+  assert.equal(hasUrlChanged("https://example.com/product"), true);
+  assert.equal(hasUrlChanged("https://example.com/product?id=1"), true);
+  assert.equal(hasUrlChanged("https://example.com/product?id=1#details"), true);
+});


### PR DESCRIPTION
## What changed

- Detect URL changes inside an already-loaded document.
- Debounce and rerun page-context extraction after client-side navigation.
- Listen for history/hash navigation, DOM updates, and use a lightweight fallback URL check.
- Add unit coverage for path, query, and hash change detection.

## Why

The content script currently computes matches only once at document startup. Single-page applications can replace the URL and product content without loading a new document, leaving the badge and warning popup associated with the previous page.

## Impact

Matches are recalculated after SPA navigation without requiring a manual reload.

## Validation

- `npx prettier --check`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` (117 passing)
- `npm run build` (Chrome and Firefox)