### PR TITLE
fix: propagate manual refresh failures

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -78,8 +78,10 @@ const loadDatasetCache = async (options?: {
     return await datasetLoadPromise;
   } catch (error) {
     console.log(`${Constants.LOG_PREFIX} Dataset load failed`, error);
-    datasetCache = [];
     nextDatasetRefreshCheckAt = 0;
+    if (forceRefresh) throw error;
+
+    datasetCache = [];
     return datasetCache;
   } finally {
     datasetLoadPromise = null;


### PR DESCRIPTION
## What changed

- Re-throw failures from explicitly forced dataset refreshes.
- Preserve the last valid in-memory dataset when a forced refresh fails.
- Reset the refresh check deadline so a later page context can retry.
- Keep the existing empty-dataset fallback for non-forced startup loads.

## Why

`Dataset.refreshNow()` records and throws network failures, but the background cache wrapper swallowed them and returned success. The options page therefore never entered its refresh error path, and the valid in-memory dataset was unnecessarily discarded.

## Impact

The manual refresh control now reports failures accurately without disrupting currently cached warning data.

## Validation

- `npx prettier --check`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` (115 passing)
- `npm run build` (Chrome and Firefox)