### PR TITLE
Fix matching behind regional URL prefixes

### DIFF
--- a/src/lib/matching/urlMatching.ts
+++ b/src/lib/matching/urlMatching.ts
@@ -39,7 +39,7 @@ export const normalizePath = (pathname: string): string => {
 };
 
 const isRegionalPathPrefix = (value: string): boolean => {
-  const normalized = value.toLowerCase().replaceAll("_", "-");
+  const normalized = value.toLowerCase().replace(/_/g, "-");
   if (matchingConfig.crossTldCountryCodeSuffixes.includes(normalized)) {
     return true;
   }

--- a/src/lib/matching/urlMatching.ts
+++ b/src/lib/matching/urlMatching.ts
@@ -38,6 +38,35 @@ export const normalizePath = (pathname: string): string => {
   return clean.replace(/\/+$/, "");
 };
 
+const isRegionalPathPrefix = (value: string): boolean => {
+  const normalized = value.toLowerCase().replaceAll("_", "-");
+  if (matchingConfig.crossTldCountryCodeSuffixes.includes(normalized)) {
+    return true;
+  }
+
+  try {
+    return Boolean(new Intl.Locale(normalized).region);
+  } catch {
+    return false;
+  }
+};
+
+const getVisitedPathVariants = (pathname: string): string[] => {
+  const variants = [pathname];
+  const segments = pathname.split("/").filter(Boolean);
+  const leadingSegment = segments[0];
+
+  if (
+    segments.length > 1 &&
+    leadingSegment &&
+    isRegionalPathPrefix(leadingSegment)
+  ) {
+    variants.push(`/${segments.slice(1).join("/")}`);
+  }
+
+  return variants;
+};
+
 export const getDomainRoot = (hostname: string): string => {
   const normalized = normalizeHostname(hostname);
   const registrableDomain = getDomain(normalized, {
@@ -103,14 +132,18 @@ export const classifyUrlMatch = (
   const candidateHost = normalizeHostname(candidateUrl.hostname);
   const visitedPath = normalizePath(visitedUrl.pathname);
   const candidatePath = normalizePath(candidateUrl.pathname);
-  const candidatePathMatchesVisitedPath =
-    visitedPath === candidatePath ||
-    visitedPath.startsWith(
-      candidatePath === "/" ? candidatePath : `${candidatePath}/`,
-    );
+  const visitedPathVariants = getVisitedPathVariants(visitedPath);
+  const exactPathMatch = visitedPathVariants.some(
+    (path) => path === candidatePath,
+  );
+  const candidatePathMatchesVisitedPath = visitedPathVariants.some(
+    (path) =>
+      path === candidatePath ||
+      path.startsWith(candidatePath === "/" ? "/" : `${candidatePath}/`),
+  );
 
   if (visitedHost === candidateHost) {
-    if (visitedPath === candidatePath) {
+    if (exactPathMatch) {
       return {
         matchType: "exact",
         matchedPath: candidatePath,
@@ -122,7 +155,7 @@ export const classifyUrlMatch = (
     }
 
     const prefix = candidatePath === "/" ? "/" : `${candidatePath}/`;
-    if (visitedPath.startsWith(prefix)) {
+    if (visitedPathVariants.some((path) => path.startsWith(prefix))) {
       return {
         matchType: "partial",
         matchedPath: candidatePath,

--- a/src/lib/matching/urlMatching.ts
+++ b/src/lib/matching/urlMatching.ts
@@ -127,16 +127,16 @@ const hasConfiguredCompoundCountrySuffix = (
 export const classifyUrlMatch = (
   visitedUrl: URL,
   candidateUrl: URL,
+  visitedPathVariants?: string[],
 ): UrlMatchDetail | null => {
   const visitedHost = normalizeHostname(visitedUrl.hostname);
   const candidateHost = normalizeHostname(candidateUrl.hostname);
   const visitedPath = normalizePath(visitedUrl.pathname);
   const candidatePath = normalizePath(candidateUrl.pathname);
-  const visitedPathVariants = getVisitedPathVariants(visitedPath);
-  const exactPathMatch = visitedPathVariants.some(
-    (path) => path === candidatePath,
-  );
-  const candidatePathMatchesVisitedPath = visitedPathVariants.some(
+  const pathVariants =
+    visitedPathVariants ?? getVisitedPathVariants(visitedPath);
+  const exactPathMatch = pathVariants.some((path) => path === candidatePath);
+  const candidatePathMatchesVisitedPath = pathVariants.some(
     (path) =>
       path === candidatePath ||
       path.startsWith(candidatePath === "/" ? "/" : `${candidatePath}/`),
@@ -155,7 +155,7 @@ export const classifyUrlMatch = (
     }
 
     const prefix = candidatePath === "/" ? "/" : `${candidatePath}/`;
-    if (visitedPathVariants.some((path) => path.startsWith(prefix))) {
+    if (pathVariants.some((path) => path.startsWith(prefix))) {
       return {
         matchType: "partial",
         matchedPath: candidatePath,
@@ -436,6 +436,10 @@ export const matchEntriesByUrl = (
   const visitedUrl = safeParseUrl(visitedUrlRaw);
   if (!visitedUrl) return [];
 
+  const visitedPathVariants = getVisitedPathVariants(
+    normalizePath(visitedUrl.pathname),
+  );
+
   const matches: DetailedUrlEntryMatch[] = [];
   for (const entry of entries) {
     const websiteUrls = splitWebsiteUrls(getEntryWebsite(entry));
@@ -444,7 +448,11 @@ export const matchEntriesByUrl = (
       const candidateUrl = safeParseUrl(websiteUrl);
       if (!candidateUrl) continue;
 
-      const detail = classifyUrlMatch(visitedUrl, candidateUrl);
+      const detail = classifyUrlMatch(
+        visitedUrl,
+        candidateUrl,
+        visitedPathVariants,
+      );
       if (!detail) continue;
 
       matches.push({

--- a/tests/urlMatching.test.ts
+++ b/tests/urlMatching.test.ts
@@ -80,6 +80,78 @@ test("classifies partial when visited path is a deeper prefix on same host", () 
   assert.equal(result.matchedPath, "/invest");
 });
 
+test("matches a product path behind a leading country-code segment", () => {
+  const dataset: CargoEntry[] = [
+    entry({
+      _type: "Company",
+      PageID: "company-apple",
+      PageName: "Apple",
+      Website: "https://apple.com/",
+    }),
+    entry({
+      _type: "ProductLine",
+      PageID: "pl-airpods",
+      PageName: "AirPods",
+      Company: "Apple",
+      Website: "https://apple.com/airpods",
+    }),
+  ];
+
+  const results = matchEntriesByUrl(
+    dataset,
+    "https://www.apple.com/au/airpods/",
+    10,
+  );
+
+  assert.equal(results[0]?.entry.PageID, "pl-airpods");
+  assert.equal(results[0]?.matchType, "exact");
+  assert.equal(results[1]?.entry.PageID, "company-apple");
+});
+
+test("partially matches a deeper product path behind a country-code segment", () => {
+  const visited = safeParseUrl("https://www.apple.com/au/airpods/compare");
+  const candidate = safeParseUrl("https://apple.com/airpods");
+  assert.ok(visited);
+  assert.ok(candidate);
+
+  const result = classifyUrlMatch(visited, candidate);
+  assert.ok(result);
+  assert.equal(result.matchType, "partial");
+  assert.equal(result.matchedPath, "/airpods");
+});
+
+test("matches a product path behind a BCP 47 locale segment", () => {
+  const visited = safeParseUrl("https://www.nvidia.com/en-au/geforce-now/");
+  const candidate = safeParseUrl("https://www.nvidia.com/geforce-now/");
+  assert.ok(visited);
+  assert.ok(candidate);
+
+  const result = classifyUrlMatch(visited, candidate);
+  assert.ok(result);
+  assert.equal(result.matchType, "exact");
+  assert.equal(result.matchedPath, "/geforce-now");
+});
+
+test("matches a product path behind an underscore locale segment", () => {
+  const visited = safeParseUrl("https://example.com/en_AU/products/widget");
+  const candidate = safeParseUrl("https://example.com/products/widget");
+  assert.ok(visited);
+  assert.ok(candidate);
+
+  const result = classifyUrlMatch(visited, candidate);
+  assert.ok(result);
+  assert.equal(result.matchType, "exact");
+});
+
+test("does not strip an unknown leading path segment", () => {
+  const visited = safeParseUrl("https://www.apple.com/store/airpods");
+  const candidate = safeParseUrl("https://apple.com/airpods");
+  assert.ok(visited);
+  assert.ok(candidate);
+
+  assert.equal(classifyUrlMatch(visited, candidate), null);
+});
+
 test("does not partial-match when candidate is deeper than visited path", () => {
   const visited = safeParseUrl("https://www.ally.com/invest/hello");
   const candidate = safeParseUrl(


### PR DESCRIPTION
## Summary

- recognize leading ISO country path segments such as `/au/`
- recognize BCP 47 locale path segments such as `/en-au/` and `/en_AU/`
- compare the remaining path with canonical Cargo website paths
- preserve ordinary path segments such as `/store/` to avoid broad suffix matching

## Root cause

Cargo entries use canonical product paths such as `/airpods`, while regional sites may redirect visitors to localized paths such as `/au/airpods`. The matcher required the candidate path to be a literal prefix of the visited path, so it returned only the company root match.

## Impact

Regional product pages now select their specific Product or ProductLine entry while retaining the existing company relationship and ranking behavior.

## Validation

- `npm test` — 132 tests passed
- `npm run build` — Chrome and Firefox builds passed
- regression coverage added for country, BCP 47, underscore-locale, deeper-path, and non-regional path cases