### PR TITLE
fix: manifest.json missing from dist root after vite-plugin-static-copy v4 update

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,11 @@ export default defineConfig({
     react(),
     viteStaticCopy({
       targets: [
-        { src: getManifestSrc(), dest: ".", rename: "manifest.json" }
+        {
+          src: getManifestSrc(),
+          dest: ".",
+          rename: { stripBase: true, name: "manifest.json" }
+        }
       ]
     })
   ],


### PR DESCRIPTION
Hello! Thank you for merging the previous fixes so quickly.

While syncing my fork after #175 I noticed that a fresh `npm run build` now places the manifest at `dist/<browser>/manifest/manifest.json` instead of `dist/<browser>/manifest.json`.

**Cause:** #175 updated `vite-plugin-static-copy` from v3.1.4 to v4.1.1. In v4 the plugin preserves the source directory structure under `dest`, so `{ src: "manifest/chrome.json", dest: ".", rename: "manifest.json" }` now keeps the `manifest/` folder from the source path.

**Impact:** Chrome and Firefox refuse to load a package without a root `manifest.json`, so the zips produced by `cd.yml` would ship broken in the next release. (I verified the v1.0.35 release zip is fine — it predates the update.)

**Fix:** use the v4 rename object with `stripBase` to flatten the copy:

```ts
rename: { stripBase: true, name: "manifest.json" }
```

**Verified:** after the change, `npm run build` puts `manifest.json` back at the root of both `dist/chrome` and `dist/firefox`, and the Chrome build loads via "Load unpacked".

This contribution was written with AI assistance (Claude); I have reviewed and tested the change myself. Happy to adjust anything!

🤖 Generated with [Claude Code](https://claude.com/claude-code)