### PR TITLE
chore: clean up web_accessible_resources (remove dead data.json, add use_dynamic_url)

### DIFF
--- a/manifest/chrome.json
+++ b/manifest/chrome.json
@@ -50,13 +50,13 @@
   "web_accessible_resources": [
     {
       "resources": [
-        "assets/data.json",
         "crw_logo.png",
         "open-in-new.svg",
         "settings.svg",
         "close.svg"
       ],
-      "matches": ["<all_urls>"]
+      "matches": ["<all_urls>"],
+      "use_dynamic_url": true
     }
   ]
 }

--- a/manifest/firefox.json
+++ b/manifest/firefox.json
@@ -51,7 +51,6 @@
   "web_accessible_resources": [
     {
       "resources": [
-        "assets/data.json",
         "crw_logo.png",
         "open-in-new.svg",
         "settings.svg",


### PR DESCRIPTION
Hello! Two small hardening tweaks to `web_accessible_resources` in both manifests:

1. **Remove `assets/data.json`** — the build never emits this file (the dataset is fetched from `DATA_REMOTE_URL` and cached in `storage.local`), so the entry only exposes a dead path.

2. **Add `use_dynamic_url: true` (Chrome manifest only)** — the four icons the content script injects stay web-accessible, but Chrome serves them from a per-session dynamic URL. Without it, any website can probe `chrome-extension://<id>/crw_logo.png` to detect that a visitor has the extension installed, which is a small fingerprinting vector. Firefox does not support `use_dynamic_url`, so the Firefox manifest keeps static URLs there.

**Verified:** `npm run build` succeeds for both targets and the inline popup icons still load in Chrome.

This contribution was written with AI assistance (Claude); I have reviewed and tested the change myself. Happy to adjust anything!

🤖 Generated with [Claude Code](https://claude.com/claude-code)