### PR TITLE
fix: log content script startup only in dev builds

### DIFF
--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -39,10 +39,12 @@ import {
 } from "@/lib/matching/ecommerce";
 import { createUrlChangeDebouncer } from "@/content/urlChangeDetector";
 
-console.log(
-  `${Constants.LOG_PREFIX} Content script loaded on:`,
-  window.location.href,
-);
+if (import.meta.env.DEV) {
+  console.log(
+    `${Constants.LOG_PREFIX} Content script loaded on:`,
+    window.location.href,
+  );
+}
 
 const POPUP_ID = "crw-inline-alert";
 const ASSET_URLS = {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
Hello! Small polish: the content script currently logs the full page URL to the console of every page it runs on. Site owners and users see `[CRW_EXTENSION] Content script loaded on: …` in the console on every site, which is a bit noisy for a production extension.

This gates the startup log behind `import.meta.env.DEV`, so it still shows up in development builds but is compiled out of production output (verified the string is absent from `dist/chrome/assets/content.js` after `npm run build`). Also adds `src/vite-env.d.ts` so TypeScript picks up Vite client types for `import.meta.env`.

**Verified:** `npx tsc --noEmit`, `npm run lint`, `npm test`, and `npm run build` all pass.

This contribution was written with AI assistance (Claude); I have reviewed and tested the change myself. Happy to adjust anything!

🤖 Generated with [Claude Code](https://claude.com/claude-code)