### PR TITLE
Fix popup progress bar corner radius

### DIFF
--- a/src/content/PopupDismissBar.tsx
+++ b/src/content/PopupDismissBar.tsx
@@ -98,25 +98,36 @@ export const PopupDismissBar = ({
       aria-valuemax={timeoutMs}
       style={{
         position: "absolute",
-        // Keep the bar inside the card's border instead of clipping the whole
-        // card, which would also clip tooltips that intentionally overflow it.
-        bottom: "1px",
-        left: "1px",
-        right: "1px",
-        height: "3px",
-        borderRadius: "0 0 12px 12px",
+        // Use a corner-height clipping wrapper: applying a 14px radius directly
+        // to the 3px track would cause CSS to clamp the radius to 1.5px.
+        bottom: "-1px",
+        left: "-1px",
+        right: "-1px",
+        height: "14px",
+        borderRadius: "0 0 14px 14px",
         overflow: "hidden",
-        background: "rgba(255,255,255,0.12)",
+        pointerEvents: "none",
       }}
     >
       <div
         style={{
-          height: "100%",
-          width: `${remaining * 100}%`,
-          background: POPUP_CSS.text,
-          opacity: 0.5,
+          position: "absolute",
+          bottom: 0,
+          left: 0,
+          right: 0,
+          height: "3px",
+          background: "rgba(255,255,255,0.12)",
         }}
-      />
+      >
+        <div
+          style={{
+            height: "100%",
+            width: `${remaining * 100}%`,
+            background: POPUP_CSS.text,
+            opacity: 0.5,
+          }}
+        />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary

- align the auto-dismiss progress bar with the dialog's bottom edge
- clip the 3px progress track through a 14px-high wrapper so it follows the dialog's rounded corners
- keep the wrapper transparent and non-interactive so tooltips and controls remain unaffected

<img width="504" height="493" alt="image" src="https://github.com/user-attachments/assets/0742af38-5364-409f-a9f9-a035f1b01597" />


## Root cause

The corner radius was applied directly to a 3px-high element. CSS scales oversized radii to fit the element, reducing the effective bottom radius to roughly 1.5px and making the bar appear square.

## Impact

The progress bar now sits flush with the dialog and respects its 14px bottom corner radius.

## Validation

- `npm test` - 127 tests passed
- `npx eslint src/content/PopupDismissBar.tsx`
- `npm run build` - Chrome and Firefox production builds passed
