### PR TITLE
feat: add About & Feedback links to Options page

### DIFF
--- a/src/options/OptionsView.tsx
+++ b/src/options/OptionsView.tsx
@@ -34,6 +34,21 @@ const POPUP_POSITION_OPTIONS: {
   { value: "bottom-right", label: "Bottom right", corner: [true, false] },
 ];
 
+const ABOUT_LINKS = [
+  {
+    href: "https://github.com/FULU-Foundation/CRW-Extension",
+    label: "Source code on GitHub",
+  },
+  {
+    href: "https://github.com/FULU-Foundation/CRW-Extension/issues",
+    label: "Report a bug or request a feature",
+  },
+  {
+    href: "https://consumerrights.wiki",
+    label: "Visit the Consumer Rights Wiki",
+  },
+] as const;
+
 const CURSOR_OUT_BEHAVIOR_OPTIONS: {
   value: AutoDismissCursorOutBehavior;
   label: string;
@@ -1177,6 +1192,65 @@ export const OptionsView = (props: OptionsViewProps) => {
                 Last fetch error: {lastRefreshError}
               </div>
             )}
+          </div>
+        </section>
+
+        <section
+          style={{
+            border: `1px solid ${PAGE_CSS.border}`,
+            borderRadius: "12px",
+            padding: "14px",
+            background: PAGE_CSS.subtleBg,
+          }}
+        >
+          <h2
+            style={{
+              margin: 0,
+              fontSize: "16px",
+              lineHeight: 1.2,
+              fontWeight: 700,
+              color: PAGE_CSS.text,
+            }}
+          >
+            About &amp; Feedback
+          </h2>
+          <p
+            style={{
+              margin: "6px 0 10px 0",
+              fontSize: "13px",
+              color: PAGE_CSS.muted,
+            }}
+          >
+            This extension is open source and maintained by the FULU
+            Foundation. Found a bug or have a suggestion? Let us know.
+          </p>
+
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "8px",
+              border: `1px solid ${PAGE_CSS.border}`,
+              borderRadius: "10px",
+              padding: "10px 12px",
+              fontSize: "13px",
+            }}
+          >
+            {ABOUT_LINKS.map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  color: PAGE_CSS.text,
+                  textDecoration: "underline",
+                  textUnderlineOffset: "2px",
+                }}
+              >
+                {link.label}
+              </a>
+            ))}
           </div>
         </section>
       </div>

--- a/src/options/OptionsView.tsx
+++ b/src/options/OptionsView.tsx
@@ -1221,8 +1221,8 @@ export const OptionsView = (props: OptionsViewProps) => {
               color: PAGE_CSS.muted,
             }}
           >
-            This extension is open source and maintained by the FULU
-            Foundation. Found a bug or have a suggestion? Let us know.
+            This extension is open source and maintained by the FULU Foundation.
+            Found a bug or have a suggestion? Let us know.
           </p>
 
           <div


### PR DESCRIPTION
## Description

Adds an **About & Feedback** section at the bottom of the Options page with links to:

- the GitHub repository
- the issue tracker (report a bug / request a feature)
- the Consumer Rights Wiki

## Motivation

Addresses #163 — users currently have no way to find the repository or issue tracker from the extension itself. The web store listing update mentioned in that issue is still pending, and an in-extension link works regardless of which store the user installed from.

## Changes

- `src/options/OptionsView.tsx`: new static `About & Feedback` section following the existing section styling; links open in a new tab with `rel="noopener noreferrer"`.

## Testing

- `npm run lint` — clean
- `npm test` — 127/127 pass
- `npm run build-chrome` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)