### PR TITLE
Prevent stale match results after navigation

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -45,6 +45,25 @@ const sendMessageToTab = async (
   }
 };
 
+const sendMatchResultsToTab = async (
+  tabId: number,
+  matches: CargoEntry[],
+): Promise<void> => {
+  try {
+    await browser.tabs.sendMessage(
+      tabId,
+      Messaging.createMessage(
+        MessageType.MATCH_RESULTS_UPDATED,
+        "background",
+        matches,
+      ),
+    );
+  } catch {
+    // A failed match update means the page is no longer available. Its next
+    // content-script context update will calculate and deliver fresh matches.
+  }
+};
+
 const readActiveTabId = async (): Promise<number | null> => {
   const tabs = await browser.tabs.query({
     active: true,
@@ -277,7 +296,6 @@ Messaging.createBackgroundMessageHandler({
       loadDatasetCache(),
       waitForNavigationCleanup(tabId),
     ]);
-    if (!tabNavigationState.isCurrent(tabId, navigationGeneration)) return;
 
     let currentTab: browser.Tabs.Tab;
     try {
@@ -301,20 +319,20 @@ Messaging.createBackgroundMessageHandler({
     });
     if (!tabNavigationState.isCurrent(tabId, navigationGeneration)) return;
 
+    try {
+      currentTab = await browser.tabs.get(tabId);
+    } catch {
+      return;
+    }
+    if (!isCurrentPageUrl(payload.url, currentTab.url)) return;
+
     browser.action.setBadgeText({
       tabId,
       text: getBadgeText(matches.length),
     });
     browser.action.setBadgeBackgroundColor({ tabId, color: "#FF5722" });
 
-    void sendMessageToTab(
-      tabId,
-      Messaging.createMessage(
-        MessageType.MATCH_RESULTS_UPDATED,
-        "background",
-        matches,
-      ),
-    );
+    void sendMatchResultsToTab(tabId, matches);
   },
 });
 

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -563,6 +563,7 @@ browser.storage.onChanged.addListener((changes, areaName) => {
 const schedulePageContextRefreshForUrl = createUrlChangeDebouncer({
   initialUrl: location.href,
   delayMs: 300,
+  onUrlChange: removeInlinePopup,
   onRefresh: () => void runContentScript(),
   setTimer: (callback, delayMs) => window.setTimeout(callback, delayMs),
   clearTimer: (timer) => window.clearTimeout(timer),

--- a/src/content/urlChangeDetector.ts
+++ b/src/content/urlChangeDetector.ts
@@ -13,6 +13,7 @@ export const createUrlChangeDetector = (
 interface UrlChangeDebouncerOptions {
   initialUrl: string;
   delayMs: number;
+  onUrlChange?: () => void;
   onRefresh: () => void;
   setTimer: (callback: () => void, delayMs: number) => number;
   clearTimer: (timer: number) => void;
@@ -21,6 +22,7 @@ interface UrlChangeDebouncerOptions {
 export const createUrlChangeDebouncer = ({
   initialUrl,
   delayMs,
+  onUrlChange,
   onRefresh,
   setTimer,
   clearTimer,
@@ -31,6 +33,7 @@ export const createUrlChangeDebouncer = ({
   return (currentUrl: string): void => {
     const urlChanged = hasUrlChanged(currentUrl);
     if (!urlChanged && pendingRefresh === null) return;
+    if (urlChanged) onUrlChange?.();
 
     if (pendingRefresh !== null) {
       clearTimer(pendingRefresh);

--- a/tests/urlChangeDetector.test.ts
+++ b/tests/urlChangeDetector.test.ts
@@ -59,3 +59,22 @@ test("debounces mutations while a URL refresh is pending", () => {
   scheduleRefresh("https://example.com/second");
   assert.equal(timers.size, 0);
 });
+
+test("notifies immediately when a new URL is detected", () => {
+  let changeCount = 0;
+  const scheduleRefresh = createUrlChangeDebouncer({
+    initialUrl: "https://example.com/first",
+    delayMs: 300,
+    onUrlChange: () => {
+      changeCount += 1;
+    },
+    onRefresh: () => undefined,
+    setTimer: () => 1,
+    clearTimer: () => undefined,
+  });
+
+  scheduleRefresh("https://example.com/second");
+  scheduleRefresh("https://example.com/second");
+
+  assert.equal(changeCount, 1);
+});


### PR DESCRIPTION
## What changed

- Do not retry automatic match-result messages. If delivery fails while a page unloads, the next page sends its own context update and receives fresh results.
- Re-check the active tab URL before storing or delivering matches, preventing an in-flight result from being applied after navigation.
- Dismiss an existing inline card immediately when SPA navigation is detected.

## Root cause

The background previously retried every failed tab message. A Google result whose first delivery failed during navigation could be retried into a newly loaded router page. Automatic match updates now use one best-effort send; user-initiated toolbar and shortcut messages retain their existing retry behavior.

A likely sequence:

1. You visit a Google page in tab 42. The extension calculates Google matches.
2. You navigate that same tab to 192.168.1.1.
3. The old Google page is unloading, so the background’s attempt to send its match result fails.
4. The extension used to retry that failed message 250–500 ms later.
5. The router page has now loaded in the same tab ID and its content script is listening.
6. The retry delivers the old Google matches to the router page, which renders the Google card because the message contained matches but no “this belongs to URL X” identity.

## Validation

- `npm test` — 128 passing
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build` — Chrome and Firefox builds
