### PR TITLE
fix: give in-page popup close buttons an accessible name

### DIFF
--- a/src/content/InlineEmptyState.tsx
+++ b/src/content/InlineEmptyState.tsx
@@ -89,6 +89,8 @@ export const InlineEmptyState = (props: InlineEmptyStateProps) => {
           <button
             type="button"
             onClick={onClose}
+            aria-label="Close"
+            title="Close"
             style={{
               border: 0,
               background: "transparent",
@@ -104,7 +106,7 @@ export const InlineEmptyState = (props: InlineEmptyStateProps) => {
               padding: 0,
             }}
           >
-            ×
+            <span aria-hidden="true">×</span>
           </button>
         </div>
       </div>

--- a/src/shared/ui/MatchPopupHeader.tsx
+++ b/src/shared/ui/MatchPopupHeader.tsx
@@ -120,6 +120,8 @@ export const MatchPopupHeader = (props: MatchPopupHeaderProps) => {
               type="button"
               onClick={onClose}
               {...ghostButtonHoverHandlers}
+              aria-label="Close"
+              title="Close"
               style={{
                 ...headerIconButtonStyle,
               }}

--- a/tests/inlineEmptyState.component.test.ts
+++ b/tests/inlineEmptyState.component.test.ts
@@ -21,3 +21,16 @@ test("InlineEmptyState renders CRW branding and empty-state message", () => {
   assert.ok(html.includes("Open extension settings"));
   assert.ok(html.includes("There are no matching articles."));
 });
+
+test("InlineEmptyState close button exposes an accessible name", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(InlineEmptyState, {
+      logoUrl: "/logo.png",
+      settingsIconUrl: "/settings.svg",
+      onOpenSettings: noop,
+      onClose: noop,
+    }),
+  );
+
+  assert.ok(html.includes('aria-label="Close"'));
+});

--- a/tests/matchPopupCard.component.test.ts
+++ b/tests/matchPopupCard.component.test.ts
@@ -73,6 +73,28 @@ test("MatchPopupCard incident list shows first status token and sorts active inc
   assert.equal(html.includes("Investigating"), false);
 });
 
+test("MatchPopupCard close button exposes an accessible name", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(MatchPopupCard, {
+      matches: [
+        entry({
+          _type: "Company",
+          PageID: "company-apple",
+          PageName: "Apple",
+        }),
+      ],
+      logoUrl: "/logo.png",
+      externalIconUrl: "/open-in-new.svg",
+      closeIconUrl: "/close.svg",
+      onSuppressSite: noop,
+      onClose: noop,
+      showCloseButton: true,
+    }),
+  );
+
+  assert.ok(html.includes('aria-label="Close"'));
+});
+
 test("MatchPopupCard renders snooze action when handler is provided", () => {
   const html = renderToStaticMarkup(
     React.createElement(MatchPopupCard, {


### PR DESCRIPTION
## Problem

The **close button** in the in-page match popup had no accessible name. In `MatchPopupHeader`, the button rendered only an `aria-hidden` icon `<img>` with no `aria-label` or `title`, so screen readers announced it as an unnamed **"button"** — a WCAG 2.1 **4.1.2 Name, Role, Value** failure. The settings button right beside it is already labeled (`aria-label="Open extension settings"`), so this was an inconsistency, not a design choice.

The empty-state popup's close button (`InlineEmptyState`) exposed only its raw `×` glyph as its name, which assistive tech announces as "multiplication sign".

## Fix

- `MatchPopupHeader` close button: add `aria-label="Close"` + `title="Close"`.
- `InlineEmptyState` close button: add `aria-label="Close"` + `title="Close"`, and mark the `×` glyph `aria-hidden`.

This matches the pattern already used by the settings buttons and the browser-action popup's "Dismiss popup" button. No visual or behavioral change for sighted users.

## Tests

Added component tests asserting each close button exposes an accessible name (`aria-label="Close"`) in the rendered markup.

- `npm test` — 129 passing (was 127; +2)
- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npm run build` — chrome + firefox build clean

Implemented with AI assistance (Claude); I reviewed and tested the changes.